### PR TITLE
(SIMP-393) Fixed order of pam_mkhomedir

### DIFF
--- a/build/pupmod-pam.spec
+++ b/build/pupmod-pam.spec
@@ -1,7 +1,7 @@
 Summary: PAM Puppet Module
 Name: pupmod-pam
 Version: 4.1.0
-Release: 10
+Release: 11
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -60,6 +60,10 @@ mkdir -p %{buildroot}/%{prefix}/pam
 # Post uninstall stuff
 
 %changelog
+* Fri Sep 18 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-11
+- Moved pam_mkhomedir to before pam_systemd to fix issues with systemd
+  subsystem failures occuring due to a lack of a home directory.
+
 * Sat May 16 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-10
 - Slight update to more closely align with the STIG.
 

--- a/templates/etc/pam.d/auth.erb
+++ b/templates/etc/pam.d/auth.erb
@@ -147,6 +147,7 @@ end
 session = [
   'session      optional      pam_keyinit.so revoke',
   'session      required      pam_limits.so',
+  'session      optional      pam_oddjob_mkhomedir.so silent',
   '-session     optional      pam_systemd.so',
   'session      sufficient    pam_succeed_if.so service = gdm-launch-environment quiet',
   'session      sufficient    pam_succeed_if.so service in crond quiet use_uid',
@@ -160,7 +161,6 @@ if @use_openshift then
 end
 
 session << 'session     requisite     pam_access.so nodefgroup'
-session << 'session      optional      pam_oddjob_mkhomedir.so silent'
 
 if @use_sssd then
   session << 'session     optional      pam_sss.so'


### PR DESCRIPTION
This update moves pam_mkhomedir to higher in the stack than pam_systemd.

Systemd errors were occuring during login due to a lack of a home
directory for the user.

SIMP-393 #close