### PR TITLE
(SIMP-556) Replace lsb* facts

### DIFF
--- a/build/pupmod-pam.spec
+++ b/build/pupmod-pam.spec
@@ -1,7 +1,7 @@
 Summary: PAM Puppet Module
 Name: pupmod-pam
 Version: 4.1.0
-Release: 11
+Release: 12
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -60,6 +60,10 @@ mkdir -p %{buildroot}/%{prefix}/pam
 # Post uninstall stuff
 
 %changelog
+* Tue Oct 27 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-12
+- Removed all calls to the lsb* facts and replaced them with 'operatingsystem*'
+  facts
+
 * Fri Sep 18 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-11
 - Moved pam_mkhomedir to before pam_systemd to fix issues with systemd
   subsystem failures occuring due to a lack of a home directory.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -249,7 +249,7 @@ class pam (
   package { 'pam_pkcs11': ensure => 'latest' }
 
   if $::operatingsystem in ['RedHat','CentOS']
-    and versioncmp($::lsbmajdistrelease,'5') > 0 {
+    and versioncmp($::operatingsystemmajrelease,'5') > 0 {
     package { 'fprintd-pam': ensure => 'latest' }
   }
 

--- a/spec/classes/access_spec.rb
+++ b/spec/classes/access_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe 'pam::access' do
   let(:facts){{
     :operatingsystem => 'CentOS',
-    :lsbdistrelease => '6.5',
-    :lsbmajdistrelease => '6'
+    :operatingsystemrelease => '6.5',
+    :operatingsystemmajrelease => '6'
   }}
 
   it { should compile.with_all_deps }

--- a/spec/classes/auth_spec.rb
+++ b/spec/classes/auth_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe 'pam::auth' do
   let(:facts){{
     :operatingsystem => 'CentOS',
-    :lsbdistrelease => '6.5',
-    :lsbmajdistrelease => '6'
+    :operatingsystemrelease => '6.5',
+    :operatingsystemmajrelease => '6'
   }}
 
   # This needs more time than we can give it right now, so it has been

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe 'pam' do
   let(:facts){{
     :operatingsystem => 'CentOS',
-    :lsbdistrelease => '6.5',
-    :lsbmajdistrelease => '6'
+    :operatingsystemrelease => '6.5',
+    :operatingsystemmajrelease => '6'
   }}
 
   it { should compile.with_all_deps }

--- a/spec/classes/limits_conf.rb
+++ b/spec/classes/limits_conf.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe 'pam::limits' do
   let(:facts){{
     :operatingsystem => 'CentOS',
-    :lsbdistrelease => '6.5',
-    :lsbmajdistrelease => '6'
+    :operatingsystemrelease => '6.5',
+    :operatingsystemmajrelease => '6'
   }}
 
   it { should compile.with_all_deps }

--- a/spec/classes/wheel_spec.rb
+++ b/spec/classes/wheel_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe 'pam::wheel' do
   let(:facts){{
     :operatingsystem => 'CentOS',
-    :lsbdistrelease => '6.5',
-    :lsbmajdistrelease => '6'
+    :operatingsystemrelease => '6.5',
+    :operatingsystemmajrelease => '6'
   }}
   let(:params){{ :wheel_group => 'administrators' }}
 

--- a/spec/defines/access/manage_spec.rb
+++ b/spec/defines/access/manage_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe 'pam::access::manage' do
   let(:facts){{
     :operatingsystem => 'CentOS',
-    :lsbdistrelease => '6.5',
-    :lsbmajdistrelease => '6'
+    :operatingsystemrelease => '6.5',
+    :operatingsystemmajrelease => '6'
   }}
   let(:title){ 'test' }
   let(:params){{

--- a/spec/defines/limits/add_spec.rb
+++ b/spec/defines/limits/add_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe 'pam::limits::add' do
   let(:facts){{
     :operatingsystem => 'CentOS',
-    :lsbdistrelease => '6.5',
-    :lsbmajdistrelease => '6'
+    :operatingsystemrelease => '6.5',
+    :operatingsystemmajrelease => '6'
   }}
   let(:title){ 'test' }
   let(:params){{

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,14 +41,6 @@ if not File.directory?(File.join(fixture_path,'modules',module_name)) then
   FileUtils.mkdir_p(File.join(fixture_path,'modules',module_name))
 end
 
-Dir.chdir(File.join(fixture_path,'modules',module_name)) do
-  ['manifests','templates','lib'].each do |tgt|
-    if not File.symlink?(tgt) then
-      FileUtils.ln_sf("../../../../#{tgt}",tgt)
-    end
-  end
-end
-
 RSpec.configure do |c|
   c.mock_framework = :rspec
   c.mock_with :mocha

--- a/templates/etc/pam.d/auth.erb
+++ b/templates/etc/pam.d/auth.erb
@@ -3,7 +3,7 @@
 # User changes will be lost!
 <%
 def td_gt_rhel5?
-  return ( ['RedHat','CentOS'].include?(@operatingsystem) and scope.function_versioncmp([@lsbmajdistrelease,'5']) > 0 )
+  return ( ['RedHat','CentOS'].include?(@operatingsystem) and scope.function_versioncmp([@operatingsystemmajrelease,'5']) > 0 )
 end
 
 # Build the auth section:


### PR DESCRIPTION
This replaces the lsb* facts with operatingsystem* ones so that the
module can work in non-LSB compliant environments.

SIMP-556 #comment Update to use non-LSB compliant facts.