### PR TITLE
(SIMP-652) Fix SSSD logic

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -249,7 +249,7 @@ class pam (
   }
   else {
     if $use_ldap {
-      $_use_sssd = $::sssd::params::use_sssd
+      $_use_sssd = $::pam::params::use_sssd
     }
     else {
       $_use_sssd = $use_sssd


### PR DESCRIPTION
SIMP-652 #close #comment `$sssd::params` ref changed to `$pam::params`