### PR TITLE
(SIMP-667) Normalize common module assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.*.sw?
+.yardoc
+dist
+/pkg
+/spec/fixtures
+!/spec/hieradata/default.yaml
+!/spec/fixtures/site.pp
+/.rspec_system
+/.vagrant
+/.bundle
+/Gemfile.lock
+/vendor
+/junit
+/log

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,4 @@
+--log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
+--relative
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,90 @@
 ---
 language: ruby
+sudo: false
 cache: bundler
-rvm:
-    - 1.8.7
-    - 1.9.3
-    - 2.0.0
-    - 2.2.1
-install: bundle install
+before_script:
+  - bundle
+bundler_args: --without development system_tests
+before_install: rm Gemfile.lock || true
 script:
-    - 'bundle exec rake validate'
-    - 'bundle exec rake lint'
-    - 'bundle exec rake spec'
+  - bundle exec rake test
+notifications:
+  email: false
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.1
+env:
+  global:
+    - STRICT_VARIABLES=yes
+    - TRUSTED_NODE_DATA=yes
+  matrix:
+  # NOTE: `:environmentpath` was not supported before Puppet 3.5
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
+    - PUPPET_VERSION="~> 3.7.0"
+    - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.0.0"
+    - PUPPET_VERSION="~> 4.1.0"
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
-    allow_failures:
-        - rvm: 1.8.7
-        - rvm: 2.2.1
+  fast_finish: true
+  allow_failures:
+    - rvm: 1.8.7
+    - rvm: 2.1.0
+    - rvm: 2.2.1
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
+
+  exclude:
+  # Ruby 1.8.7
+  # - Ruby 1.8.7 & Puppet 4.X is impossibru
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.2.0"
+
+  # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
+  # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
+  # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+
+  # Ruby 2.1.0
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0"
+
+  # Ruby 2.2.1
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,92 @@
+This module has grown over time based on a range of contributions from
+people using it. If you follow these contributing guidelines your patch
+will likely make it into a release a little quicker.
+
+
 ## Contributing
 
-Please refer to the main [SIMP Project Contributing Guide](https://github.com/NationalSecurityAgency/SIMP/blob/master/CONTRIBUTING.md)
-for details on contributing to this project.
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, and
+   it's great to know that you have a clean slate.
+
+3. Add a test for your change. Only refactoring and documentation
+   changes require no new tests. If you are adding functionality
+   or fixing a bug, please add a test.
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+
+## Dependencies
+
+The testing and development tools have a bunch of dependencies,
+all managed by [Bundler](http://bundler.io/) according to the
+[Puppet support matrix](http://docs.puppetlabs.com/guides/platforms.html#ruby-versions).
+
+By default the tests use a baseline version of Puppet.
+
+If you have Ruby 2.x or want a specific version of Puppet,
+you must set an environment variable such as:
+
+    export PUPPET_VERSION="~> 3.2.0"
+
+Install the dependencies like so...
+
+    bundle install
+
+## Syntax and style
+
+The test suite will run [Puppet Lint](http://puppet-lint.com/) and
+[Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
+check various syntax and style things. You can run these locally with:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+
+## Running the unit tests
+
+The unit test suite covers most of the code, as mentioned above please
+add tests if you're adding new functionality. If you've not used
+[rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
+about how best to test your new feature. Running the test suite is done
+with:
+
+    bundle exec rake spec
+
+Note also you can run the syntax, style and unit tests in one go with:
+
+    bundle exec rake test
+
+### Automatically run the tests
+
+During development of your puppet module you might want to run your unit
+tests a couple of times. You can use the following command to automate
+running the unit tests on every change made in the manifests folder.
+
+    bundle exec guard
+
+## Integration tests
+
+The unit tests just check the code runs, not that it does exactly what
+we want on a real machine. For that we're using
+[Beaker](https://github.com/puppetlabs/beaker).
+
+Beaker fires up a new virtual machine (using Vagrant) and runs a series of
+simple tests against it after applying the module. You can run our
+Beaker tests with:
+
+    bundle exec rake acceptance
+
+This will use the host described in `spec/acceptance/nodeset/default.yml`
+by default. To run against another host, set the `BEAKER_set` environment
+variable to the name of a host described by a `.yml` file in the
+`nodeset` directory. For example, to run against CentOS 6.4:
+
+    BEAKER_set=centos-64-x64 bundle exec rake acceptance
+
+If you don't want to have to recreate the virtual machine every time you
+can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will
+at least need `BEAKER_provision` set to yes (the default). The Vagrantfile
+for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
@@ -15,8 +15,9 @@ group :test do
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
   gem "simp-rspec-puppet-facts"
-  # A bug the broke .ignore_paths was fixed on 30 Oct 2015:
-  gem "puppet-lint", :git => 'https://github.com/rodjek/puppet-lint.git'
+
+  # dependency hacks:
+  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
   # simp-rake-helpers does not suport puppet 2.7.X
   if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
@@ -40,7 +41,11 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers'
+
+  # 1.0.5 introduces FIPS-first acc tests
+  gem 'simp-beaker-helpers', '>= 1.0.5'
+
+  # dependency hacks:
   # NOTE: Workaround because net-ssh 2.10 is busting beaker
   # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
   gem 'net-ssh', '~> 2.9.0'

--- a/Rakefile
+++ b/Rakefile
@@ -1,27 +1,68 @@
-#!/usr/bin/rake -T
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet/version'
+require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet-lint/tasks/puppet-lint'
 
-# For playing nice with mock
-File.umask(027)
+# These gems aren't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
 
-require 'simp/rake/pkg'
+
+# Lint & Syntax exclusions
+exclude_paths = [
+  "bundle/**/*",
+  "pkg/**/*",
+  "dist/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetSyntax.exclude_paths = exclude_paths
+
+# See: https://github.com/rodjek/puppet-lint/pull/397
+Rake::Task[:lint].clear
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = PuppetLint.configuration.ignore_paths
+end
 
 begin
-  require 'puppetlabs_spec_helper/rake_tasks'
+  require 'simp/rake/pkg'
+  Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
+    t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+  end
 rescue LoadError
-  puts "== WARNING: Gem puppetlabs_spec_helper not found, spec tests cannot be run! =="
+  puts "== WARNING: Gem simp-rake-helpers not found, pkg: tasks cannot be run! =="
 end
 
-# Lint Material
 begin
-  require 'puppet-lint/tasks/puppet-lint'
-
-  PuppetLint.configuration.send("disable_80chars")
-  PuppetLint.configuration.send("disable_variables_not_enclosed")
-  PuppetLint.configuration.send("disable_class_parameter_defaults")
+  require 'simp/rake/beaker'
+  Simp::Rake::Beaker.new( File.dirname( __FILE__ ) )
 rescue LoadError
-  puts "== WARNING: Gem puppet-lint not found, lint tests cannot be run! =="
+  # Ignoring this for now since all of these are currently convenience methods.
 end
 
-Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
-  t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
 end
+
+desc "Populate CONTRIBUTORS file"
+task :contributors do
+  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
+end
+
+task :metadata do
+  sh "metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+  :metadata,
+]

--- a/manifests/access/manage.pp
+++ b/manifests/access/manage.pp
@@ -96,6 +96,12 @@ define pam::access::manage (
   $comment = '',
   $order = '1000'
 ) {
+  validate_array_member($permission,['+','-'])
+  validate_array($origins)
+  validate_integer($order)
+  if $order > '9999999999' {
+    fail('$order must be less than 9999999999.')
+  }
 
   $l_name = regsubst($name,'/','_')
   $l_origins = join($origins,' ')
@@ -109,11 +115,4 @@ define pam::access::manage (
   }
 
   concat_fragment { "pam_access+${order}.${l_name}.access": content => $content }
-
-  validate_array_member($permission,['+','-'])
-  validate_array($origins)
-  validate_integer($order)
-  if $order > '9999999999' {
-    fail('$order must be less than 9999999999.')
-  }
 }

--- a/manifests/limits/add.pp
+++ b/manifests/limits/add.pp
@@ -28,11 +28,6 @@ define pam::limits::add (
 #     by name.
     $order = '1000'
   ) {
-  $l_name = regsubst($name,'/','_')
-
-  concat_fragment { "pam_limits+${order}.${l_name}.limit":
-    content => "${domain}\t${type}\t${item}\t${value}\n"
-  }
   include 'pam::limits'
 
   validate_array_member($item,[
@@ -63,4 +58,10 @@ define pam::limits::add (
   }
   validate_array_member($type,['hard','soft','-'])
   validate_integer($order)
+
+  $l_name = regsubst($name,'/','_')
+
+  concat_fragment { "pam_limits+${order}.${l_name}.limit":
+    content => "${domain}\t${type}\t${item}\t${value}\n"
+  }
 }

--- a/manifests/wheel.pp
+++ b/manifests/wheel.pp
@@ -17,14 +17,14 @@ class pam::wheel (
 #    openshift_origin puppet code is compatible.
     $use_openshift = pick($::pam::use_openshift,false)
 ) {
+  validate_string($wheel_group)
+  validate_bool($root_only)
+  validate_bool($use_openshift)
+
   file { '/etc/pam.d/su':
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
     content => template('pam/etc/pam.d/su.erb')
   }
-
-  validate_string($wheel_group)
-  validate_bool($root_only)
-  validate_bool($use_openshift)
 }

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
   "source":  "https://github.com/simp/pupmod-simp-pam",
   "project_page": "https://github.com/simp/pupmod-simp-pam",
   "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp" ],
+  "tags": [ "simp", "pam" ],
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",

--- a/spec/classes/access_spec.rb
+++ b/spec/classes/access_spec.rb
@@ -7,22 +7,22 @@ describe 'pam::access' do
       context "on #{os}" do
         let(:facts){ facts }
 
-        it { should compile.with_all_deps }
-        it { should create_concat_build('pam_access').with({
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_concat_build('pam_access').with({
             :target         => '/etc/security/access.conf',
             :squeeze_blank  => true,
           })
         }
-        it { should create_concat_build('pam_access').that_requires('Package[pam]') }
-        it { should create_file('/etc/security/access.conf').that_subscribes_to('Concat_build[pam_access]') }
-        it { should create_pam__access__manage('default_deny').with({
+        it { is_expected.to create_concat_build('pam_access').that_requires('Package[pam]') }
+        it { is_expected.to create_file('/etc/security/access.conf').that_subscribes_to('Concat_build[pam_access]') }
+        it { is_expected.to create_pam__access__manage('default_deny').with({
             :permission => '-',
             :users      => 'ALL',
             :origins    => ['ALL'],
             :order      => '9999999999'
           })
         }
-        it { should create_pam__access__manage('allow_local_root').with({
+        it { is_expected.to create_pam__access__manage('allow_local_root').with({
             :permission => '+',
             :users      => 'root',
             :origins    => ['LOCAL'],

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -7,9 +7,9 @@ describe 'pam' do
       context "on #{os}" do
         let(:facts){ facts }
 
-        it { should compile.with_all_deps }
-        it { should contain_file('/etc/pam.d').with_mode('0644') }
-        it { should contain_file('/etc/pam.d/other').with_content(<<-EOM.gsub(/^\s+/,'')
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/etc/pam.d').with_mode('0644') }
+        it { is_expected.to contain_file('/etc/pam.d/other').with_content(<<-EOM.gsub(/^\s+/,'')
             auth    required    pam_warn.so
             account    required    pam_warn.so
             password    required    pam_warn.so
@@ -22,17 +22,17 @@ describe 'pam' do
           )
         }
 
-        it { should contain_package('pam') }
-        it { should contain_package('pam_pkcs11') }
-        it { should contain_package('fprintd-pam') }
-        it { should contain_pam__auth('fingerprint') }
-        it { should contain_pam__auth('system') }
-        it { should contain_pam__auth('password') }
-        it { should contain_pam__auth('smartcard') }
+        it { is_expected.to contain_package('pam') }
+        it { is_expected.to contain_package('pam_pkcs11') }
+        it { is_expected.to contain_package('fprintd-pam') }
+        it { is_expected.to contain_pam__auth('fingerprint') }
+        it { is_expected.to contain_pam__auth('system') }
+        it { is_expected.to contain_pam__auth('password') }
+        it { is_expected.to contain_pam__auth('smartcard') }
 
         context 'no_deny_if_unknown' do
           let(:params){{ :deny_if_unknown => false }}
-          it { should contain_file('/etc/pam.d/other').with_content(<<-EOM.gsub(/^\s+/,'')
+          it { is_expected.to contain_file('/etc/pam.d/other').with_content(<<-EOM.gsub(/^\s+/,'')
               auth    required    pam_warn.so
               account    required    pam_warn.so
               password    required    pam_warn.so
@@ -44,7 +44,7 @@ describe 'pam' do
 
         context 'no_warn_if_unknown' do
           let(:params){{ :warn_if_unknown => false }}
-          it { should contain_file('/etc/pam.d/other').with_content(<<-EOM.gsub(/^\s+/,'')
+          it { is_expected.to contain_file('/etc/pam.d/other').with_content(<<-EOM.gsub(/^\s+/,'')
               auth    required    pam_deny.so
               account    required    pam_deny.so
               password    required    pam_deny.so
@@ -59,7 +59,7 @@ describe 'pam' do
             :warn_if_unknown => false,
             :deny_if_unknown => false
           }}
-          it { should contain_file('/etc/pam.d/other').with_content("\n") }
+          it { is_expected.to contain_file('/etc/pam.d/other').with_content("\n") }
         end
       end
     end

--- a/spec/classes/limits_conf.rb
+++ b/spec/classes/limits_conf.rb
@@ -7,10 +7,10 @@ describe 'pam::limits' do
       context "on #{os}" do
         let(:facts){ facts }
 
-        it { should compile.with_all_deps }
-        it { should create_concat_build('pam_limits').with_target('/etc/security/limits.conf') }
-        it { should create_concat_build('pam_limits').that_requires('Package[pam]') }
-        it { should create_file('/etc/security/limits.conf').that_subscribes_to('Concat_build[pam_limits]') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_concat_build('pam_limits').with_target('/etc/security/limits.conf') }
+        it { is_expected.to create_concat_build('pam_limits').that_requires('Package[pam]') }
+        it { is_expected.to create_file('/etc/security/limits.conf').that_subscribes_to('Concat_build[pam_limits]') }
       end
     end
   end

--- a/spec/classes/wheel_spec.rb
+++ b/spec/classes/wheel_spec.rb
@@ -12,20 +12,20 @@ describe 'pam::wheel' do
           'include ::pam'
         }
 
-        it { should compile.with_all_deps }
+        it { is_expected.to compile.with_all_deps }
 
-        it { should create_file('/etc/pam.d/su').with_content(/required\s+pam_wheel\.so.*group=#{params[:wheel_group]}/) }
-        it { should_not create_file('/etc/pam.d/su').with_content(/root_only/) }
-        it { should_not create_file('/etc/pam.d/su').with_content(/oo-trap/) }
+        it { is_expected.to create_file('/etc/pam.d/su').with_content(/required\s+pam_wheel\.so.*group=#{params[:wheel_group]}/) }
+        it { is_expected.not_to create_file('/etc/pam.d/su').with_content(/root_only/) }
+        it { is_expected.not_to create_file('/etc/pam.d/su').with_content(/oo-trap/) }
 
         context 'root_only' do
           let(:params){{
             :wheel_group => 'administrators',
             :root_only => true
           }}
-          it { should create_file('/etc/pam.d/su').with_content(/required\s+pam_wheel\.so.*group=#{params[:wheel_group]}/) }
-          it { should create_file('/etc/pam.d/su').with_content(/root_only/) }
-          it { should_not create_file('/etc/pam.d/su').with_content(/oo-trap/) }
+          it { is_expected.to create_file('/etc/pam.d/su').with_content(/required\s+pam_wheel\.so.*group=#{params[:wheel_group]}/) }
+          it { is_expected.to create_file('/etc/pam.d/su').with_content(/root_only/) }
+          it { is_expected.not_to create_file('/etc/pam.d/su').with_content(/oo-trap/) }
         end
 
         context 'use_openshift' do
@@ -33,9 +33,9 @@ describe 'pam::wheel' do
             :wheel_group => 'administrators',
             :use_openshift => true
           }}
-          it { should create_file('/etc/pam.d/su').with_content(/required\s+pam_wheel\.so.*group=#{params[:wheel_group]}/) }
-          it { should_not create_file('/etc/pam.d/su').with_content(/root_only/) }
-          it { should create_file('/etc/pam.d/su').with_content(/oo-trap/) }
+          it { is_expected.to create_file('/etc/pam.d/su').with_content(/required\s+pam_wheel\.so.*group=#{params[:wheel_group]}/) }
+          it { is_expected.not_to create_file('/etc/pam.d/su').with_content(/root_only/) }
+          it { is_expected.to create_file('/etc/pam.d/su').with_content(/oo-trap/) }
         end
       end
     end

--- a/spec/defines/access/manage_spec.rb
+++ b/spec/defines/access/manage_spec.rb
@@ -14,9 +14,9 @@ describe 'pam::access::manage' do
           :order => '1'
         }}
 
-        it { should compile.with_all_deps }
+        it { is_expected.to compile.with_all_deps }
 
-        it { should create_concat_fragment("pam_access+#{params[:order]}.#{title}.access").with_content(<<-EOM.gsub(/^\s+/,'')
+        it { is_expected.to create_concat_fragment("pam_access+#{params[:order]}.#{title}.access").with_content(<<-EOM.gsub(/^\s+/,'')
           + : #{params[:users]} : #{params[:origins].join(' ')}
           EOM
         )}
@@ -29,7 +29,7 @@ describe 'pam::access::manage' do
             :comment => "foo\nbar\nbaz"
           }}
 
-          it { should create_concat_fragment("pam_access+#{params[:order]}.#{title}.access").with_content(<<-EOM.gsub(/^\s+/,'')
+          it { is_expected.to create_concat_fragment("pam_access+#{params[:order]}.#{title}.access").with_content(<<-EOM.gsub(/^\s+/,'')
             # foo
             # bar
             # baz

--- a/spec/defines/limits/add_spec.rb
+++ b/spec/defines/limits/add_spec.rb
@@ -16,9 +16,9 @@ describe 'pam::limits::add' do
           :order => '1'
         }}
 
-        it { should compile.with_all_deps }
+        it { is_expected.to compile.with_all_deps }
 
-        it { should create_concat_fragment("pam_limits+#{params[:order]}.#{title}.limit").with_content(
+        it { is_expected.to create_concat_fragment("pam_limits+#{params[:order]}.#{title}.limit").with_content(
           /#{Regexp.escape(params[:domain])}\s#{params[:type]}\s#{params[:item]}\s#{params[:value]}/
         )}
       end


### PR DESCRIPTION
This commit synchronizes all common static module assets with current SIMP
module standards.

Also:
- updated rspec tests to the new `expect` syntax
- moved validations to the tops of classes
- created .puppet-lint.rc, .travis.yml, .gitignore, Gemfile

SIMP-667 #comment updated `pupmod-simp-pam`
SIMP-748 #close #comment normalized common module assets
