### PR TITLE
(SIMP-970) Fix issue with pam_oddjob_mkhomedir

### DIFF
--- a/build/pupmod-pam.spec
+++ b/build/pupmod-pam.spec
@@ -1,6 +1,6 @@
 Summary: PAM Puppet Module
 Name: pupmod-pam
-Version: 4.2.0
+Version: 4.2.1
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -61,6 +61,10 @@ mkdir -p %{buildroot}/%{prefix}/pam
 # Post uninstall stuff
 
 %changelog
+* Wed Mar 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.2.1-0
+- Move pam_oddjob_mkhomedir below pam_sssd in the stack due to a odd
+  SELinux-related bug which prevented users from logging into systems via SSH.
+
 * Mon Mar 14 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.2.0-0
 - Ensure that EL6.7+ uses SSSD over NSCD
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-pam",
-  "version": "4.2.0-0",
+  "version": "4.2.1-0",
   "author":  "simp",
   "summary": "A SIMP puppet module for managing pam",
   "license": "Apache-2.0",
@@ -10,11 +10,11 @@
   "tags": [ "simp", "pam" ],
   "dependencies": [
     {
-      "name": "puppetlabs-stdlib",
+      "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.1.0"
     },
     {
-      "name": "simp-simplib",
+      "name": "simp/simplib",
       "version_requirement": ">= 1.0.0"
     },
     {

--- a/templates/etc/pam.d/auth.erb
+++ b/templates/etc/pam.d/auth.erb
@@ -141,7 +141,6 @@ end
 _session = [
   'session      optional      pam_keyinit.so revoke',
   'session      required      pam_limits.so',
-  'session      optional      pam_oddjob_mkhomedir.so silent',
   '-session     optional      pam_systemd.so',
   'session      sufficient    pam_succeed_if.so service = gdm-launch-environment quiet',
   'session      sufficient    pam_succeed_if.so service in crond quiet use_uid',
@@ -154,18 +153,19 @@ if @use_openshift
   _session << 'session      [default=ignore success=1] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user'
 end
 
-_session << 'session     requisite     pam_access.so nodefgroup'
+_session << 'session      requisite     pam_access.so nodefgroup'
 
 if @use_sssd
-  _session << 'session     optional      pam_sss.so'
+  _session << 'session      optional      pam_sss.so'
 elsif @use_ldap
-  _session << 'session     [success=1]   pam_unix.so'
-  _session << 'session     optional      pam_ldap.so ignore_unknown_user ignore_authinfo_unavail'
+  _session << 'session      [success=1]   pam_unix.so'
+  _session << 'session      optional      pam_ldap.so ignore_unknown_user ignore_authinfo_unavail'
 else
-  _session << 'session     required      pam_unix.so'
+  _session << 'session      required      pam_unix.so'
 end
 
-_session << 'session     required      pam_lastlog.so showfailed'
+_session << 'session      optional      pam_oddjob_mkhomedir.so silent'
+_session << 'session      required      pam_lastlog.so showfailed'
 -%>
 <%= _auth.join("\n") %>
 


### PR DESCRIPTION
pam_oddjob_mkhomedir was causing an ANOM_ABEND error which prevented
users from logging in over SSH.

When moved below the pam_ssh line, the logins were successful.

Disabling SELinux also allowed the user to login but this was not an
acceptable resolution.

SIMP-970 #close