### PR TITLE
(SIMP-1017) Systems should support pam_tty_audit

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,3 +2,5 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-80chars-check
+--no-empty_string-check
+--no-trailing_comma-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,66 +1,7 @@
-Summary: PAM Puppet Module
-Name: pupmod-pam
-Version: 4.2.1
-Release: 0
-License: Apache License, Version 2.0
-Group: Applications/System
-Source: %{name}-%{version}-%{release}.tar.gz
-Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
-Requires: pupmod-simpcat >= 2.0.0-0
-Requires: pupmod-oddjob >= 1.0.0-0
-Requires: pupmod-rsync >= 2.0.0-0
-Requires: pupmod-sssd >= 2.0.0-0
-Requires: puppet >= 3.3.0
-Requires: simp_rsync_filestore >= 2.0.0-2
-Buildarch: noarch
-Requires: simp-bootstrap >= 4.2.0
-Obsoletes: pupmod-pam-test
-Requires: pupmod-onyxpoint-compliance_markup
+* Thu Jul 07 2016 Liz Nemsick <elizabeth.nemsick@uscontracting.us> - 4.2.2-0
+- Added use of pam_tty_audit in system-auth, password-auth, and fingerprint-auth.
+- Updated module to use new rake helper to auto-generate RPM .spec file.
 
-Prefix: %{_sysconfdir}/puppet/environments/simp/modules
-
-%description
-This Puppet module provides the capability to configure various PAM settings on
-the system.
-
-Included are capabilities to manage:
-  * system-auth
-  * Group-based access to the system
-  * access.conf
-
-The system-auth settings are a bit draconian, but simple enough to work within.
-
-%prep
-%setup -q
-
-%build
-
-%install
-[ "%{buildroot}" != "/" ] && rm -rf %{buildroot}
-
-mkdir -p %{buildroot}/%{prefix}/pam
-
-dirs='files lib manifests templates'
-for dir in $dirs; do
-  test -d $dir && cp -r $dir %{buildroot}/%{prefix}/pam
-done
-
-%clean
-[ "%{buildroot}" != "/" ] && rm -rf %{buildroot}
-
-mkdir -p %{buildroot}/%{prefix}/pam
-
-%files
-%defattr(0640,root,puppet,0750)
-%{prefix}/pam
-
-%post
-#!/bin/sh
-
-%postun
-# Post uninstall stuff
-
-%changelog
 * Wed Mar 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.2.1-0
 - Move pam_oddjob_mkhomedir below pam_sssd in the stack due to a odd
   SELinux-related bug which prevented users from logging into systems via SSH.

--- a/Gemfile
+++ b/Gemfile
@@ -20,13 +20,15 @@ group :test do
   gem "metadata-json-lint"
   gem "simp-rspec-puppet-facts", "~> 1.3"
 
+  gem 'puppet-lint-empty_string-check',   :require => false
+  gem 'puppet-lint-trailing_comma-check', :require => false
 
   # simp-rake-helpers does not suport puppet 2.7.X
   if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
       # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
       # TODO: fix upstream deps (parallel in simp-rake-helpers)
       RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
-    gem 'simp-rake-helpers'
+    gem 'simp-rake-helpers', '>= 2.4.1'
   end
 end
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,0 +1,11 @@
+Requires: pupmod-simpcat >= 2.0.0-0
+Requires: pupmod-simplib >= 1.2.5-0
+Requires: pupmod-oddjob >= 1.0.0-0
+Requires: pupmod-rsync >= 2.0.0-0
+Requires: pupmod-sssd >= 2.0.0-0
+Requires: pupmod-onyxpoint-compliance_markup
+Requires: puppet >= 3.3.0
+Requires: puppetlabs-stdlib >= 4.9.0-0.SIMP
+Requires: simp_rsync_filestore >= 2.0.0-2
+Requires: simp-bootstrap >= 4.2.0
+Obsoletes: pupmod-pam-test

--- a/manifests/access.pp
+++ b/manifests/access.pp
@@ -22,7 +22,7 @@ class pam::access {
   }
 
   file { '/etc/security/access.conf':
-    ensure    => 'present',
+    ensure    => 'file',
     owner     => 'root',
     group     => 'root',
     mode      => '0644',

--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -25,6 +25,7 @@ define pam::auth (
   $cracklib_minlen           = $::pam::cracklib_minlen,
   $cracklib_retry            = $::pam::cracklib_retry,
   $deny                      = $::pam::deny,
+  $display_account_lock      = $::pam::display_account_lock,
   $fail_interval             = $::pam::fail_interval,
   $remember                  = $::pam::remember,
   $root_unlock_time          = $::pam::root_unlock_time,
@@ -35,7 +36,8 @@ define pam::auth (
   $use_ldap                  = $::pam::use_ldap,
   $use_netgroups             = $::pam::use_netgroups,
   $use_openshift             = $::pam::use_openshift,
-  $use_sssd                  = $::pam::_use_sssd
+  $use_sssd                  = $::pam::_use_sssd,
+  $tty_audit_enable          = $::pam::tty_audit_enable
 ) {
 
   include '::oddjob::mkhomedir'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -176,6 +176,10 @@
 #   Default: false
 #   Set PAM to work with SSSD.
 #
+# [*tty_audit_enable*]
+#   Default: [ 'root' ]
+#   The users for which TTY auditing is enabled. Set to an empty Array to not audit TTY actions for any user.
+#
 # [*auth_sections*]
 #   Default: [ 'fingerprint', 'system', 'password', 'smartcard' ]
 #   The PAM '*-auth' files to manage. Set to an empty Array to not manage any sections by default.
@@ -211,6 +215,7 @@ class pam (
   $use_netgroups             = false,
   $use_openshift             = false,
   $use_sssd                  = false,
+  $tty_audit_enable          = [ 'root' ],
   $auth_sections             = [ 'fingerprint', 'system', 'password', 'smartcard' ]
 ) inherits ::pam::params {
 
@@ -245,6 +250,7 @@ class pam (
   validate_bool($use_netgroups)
   validate_bool($use_openshift)
   validate_bool($use_sssd)
+  validate_array($tty_audit_enable)
   validate_array($auth_sections)
 
   compliance_map()

--- a/manifests/limits.pp
+++ b/manifests/limits.pp
@@ -15,7 +15,7 @@ class pam::limits {
   }
 
   file { '/etc/security/limits.conf':
-    ensure    => 'present',
+    ensure    => 'file',
     owner     => 'root',
     group     => 'root',
     mode      => '0640',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-pam",
-  "version": "4.2.1-0",
+  "version": "4.2.2",
   "author":  "simp",
   "summary": "A SIMP puppet module for managing pam",
   "license": "Apache-2.0",
@@ -11,7 +11,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 4.9.0"
     },
     {
       "name": "simp/simplib",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -62,6 +62,12 @@ describe 'pam' do
           it { is_expected.to contain_file('/etc/pam.d/other').with_content("\n") }
         end
       end
+
+      context "tty_audit_enable parameter error" do
+        let(:facts){ facts }
+        let(:params){{ :tty_audit_enable => 'root' }}
+        it { is_expected.not_to compile.with_all_deps }
+      end
     end
   end
 end

--- a/spec/defines/auth_spec.rb
+++ b/spec/defines/auth_spec.rb
@@ -9,87 +9,579 @@ describe 'pam::auth' do
         let(:pre_condition){
           'class { "::pam": auth_sections => [] }'
         }
+     
 
-        ['password','system'].each do |auth_type|
-          context "auth type '#{auth_type}'" do
-            let(:title){ auth_type }
-            let(:filename){ "/etc/pam.d/#{auth_type}-auth" }
+        # Default parameters:
+        # cracklib_reject_username  = true
+        # cracklib_gecoscheck       = true
+        # cracklib_enforce_for_root = true
+        # display_account_lock      = false
+        # use_ldap                  = false
+        # use_netgroups             = false
+        # use_openshift             = false
+        # use_sssd                  = false
+        # tty_audit_enable          = ['root']
+        context 'All default parameters' do
+          context 'fingerprint' do
+            let(:title){ 'fingerprint' }
+            let(:filename){ '/etc/pam.d/fingerprint-auth' }
 
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to create_class('oddjob::mkhomedir') }
             it { is_expected.to contain_file(filename).with_mode('0644') }
             it { is_expected.to contain_file("#{filename}-ac").with_ensure('absent') }
+            it { is_expected.to contain_file(filename).with_content(<<EOM
+#%PAM-1.0
+# This file managed by Puppet
+# User changes will be lost!
+auth     optional      pam_faildelay.so
+auth     required      pam_env.so
+auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
+auth     sufficient    pam_fprintd.so
+auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     required      pam_deny.so
 
-            it { is_expected.to contain_file(filename).with_content(
-              /^\s*password\s+sufficient\s+pam_unix\.so/m
+account     required      pam_unix.so broken_shadow
+account     required      pam_faillock.so
+account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
+account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     requisite     pam_access.so nodefgroup
+account     required      pam_permit.so
+
+password     required      pam_deny.so
+
+session      optional      pam_keyinit.so revoke
+session      required      pam_limits.so
+-session     optional      pam_systemd.so
+session      sufficient    pam_succeed_if.so service = gdm-launch-environment quiet
+session      sufficient    pam_succeed_if.so service in crond quiet use_uid
+session      sufficient    pam_succeed_if.so user = root quiet
+session      requisite     pam_access.so nodefgroup
+session      required      pam_unix.so
+session      required      pam_tty_audit.so disable=* enable=root
+session      optional      pam_oddjob_mkhomedir.so silent
+session      required      pam_lastlog.so showfailed
+EOM
               )
             }
-            it { is_expected.to contain_file(filename).without_content(
-              /^\s*password\s+sufficient\s+pam_sss\.so/m
+          end
+
+          context 'password' do
+            let(:title){ 'password' }
+            let(:filename){ '/etc/pam.d/password-auth' }
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to create_class('oddjob::mkhomedir') }
+            it { is_expected.to contain_file(filename).with_mode('0644') }
+            it { is_expected.to contain_file("#{filename}-ac").with_ensure('absent') }
+            it { is_expected.to contain_file(filename).with_content(<<EOM
+#%PAM-1.0
+# This file managed by Puppet
+# User changes will be lost!
+auth     optional      pam_faildelay.so
+auth     required      pam_env.so
+auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
+auth     sufficient    pam_unix.so try_first_pass
+auth     [default=die] pam_faillock.so authfail deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60
+auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     required      pam_deny.so
+
+account     required      pam_unix.so broken_shadow
+account     required      pam_faillock.so
+account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
+account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     requisite     pam_access.so nodefgroup
+account     required      pam_permit.so
+
+password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=14 minclass=3 maxrepeat=2 maxclassrepeat=0 maxsequence=4 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck reject_username enforce_for_root
+password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok remember=24
+password     required      pam_deny.so
+
+session      optional      pam_keyinit.so revoke
+session      required      pam_limits.so
+-session     optional      pam_systemd.so
+session      sufficient    pam_succeed_if.so service = gdm-launch-environment quiet
+session      sufficient    pam_succeed_if.so service in crond quiet use_uid
+session      sufficient    pam_succeed_if.so user = root quiet
+session      requisite     pam_access.so nodefgroup
+session      required      pam_unix.so
+session      required      pam_tty_audit.so disable=* enable=root
+session      optional      pam_oddjob_mkhomedir.so silent
+session      required      pam_lastlog.so showfailed
+EOM
               )
             }
-            it { is_expected.to contain_file(filename).without_content(
-              /^\s*password\s+sufficient\s+pam_ldap\.so/m
+          end
+
+          context 'smartcard' do
+            let(:title){ 'smartcard' }
+            let(:filename){ '/etc/pam.d/smartcard-auth' }
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to create_class('oddjob::mkhomedir') }
+            it { is_expected.to contain_file(filename).with_mode('0644') }
+            it { is_expected.to contain_file("#{filename}-ac").with_ensure('absent') }
+            it { is_expected.to contain_file(filename).with_content(<<EOM
+#%PAM-1.0
+# This file managed by Puppet
+# User changes will be lost!
+auth     optional      pam_faildelay.so
+auth     required      pam_env.so
+auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
+auth     [success=done ignore=ignore default=die] pam_pkcs11.so wait_for_card card_only
+auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     required      pam_deny.so
+
+account     required      pam_unix.so broken_shadow
+account     required      pam_faillock.so
+account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
+account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     requisite     pam_access.so nodefgroup
+account     required      pam_permit.so
+
+password     required      pam_pkcs11.so
+
+session      optional      pam_keyinit.so revoke
+session      required      pam_limits.so
+-session     optional      pam_systemd.so
+session      sufficient    pam_succeed_if.so service = gdm-launch-environment quiet
+session      sufficient    pam_succeed_if.so service in crond quiet use_uid
+session      sufficient    pam_succeed_if.so user = root quiet
+session      requisite     pam_access.so nodefgroup
+session      required      pam_unix.so
+session      optional      pam_oddjob_mkhomedir.so silent
+session      required      pam_lastlog.so showfailed
+EOM
+              )
+            }
+          end
+
+          context 'system' do
+            let(:title){ 'system' }
+            let(:filename){ '/etc/pam.d/system-auth' }
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to create_class('oddjob::mkhomedir') }
+            it { is_expected.to contain_file(filename).with_mode('0644') }
+            it { is_expected.to contain_file("#{filename}-ac").with_ensure('absent') }
+            it { is_expected.to contain_file(filename).with_content(<<EOM
+#%PAM-1.0
+# This file managed by Puppet
+# User changes will be lost!
+auth     optional      pam_faildelay.so
+auth     required      pam_env.so
+auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
+auth     sufficient    pam_unix.so try_first_pass
+auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     required      pam_deny.so
+
+account     required      pam_unix.so broken_shadow
+account     required      pam_faillock.so
+account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
+account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     requisite     pam_access.so nodefgroup
+account     required      pam_permit.so
+
+password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=14 minclass=3 maxrepeat=2 maxclassrepeat=0 maxsequence=4 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck reject_username enforce_for_root
+password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok remember=24
+password     required      pam_deny.so
+
+session      optional      pam_keyinit.so revoke
+session      required      pam_limits.so
+-session     optional      pam_systemd.so
+session      sufficient    pam_succeed_if.so service = gdm-launch-environment quiet
+session      sufficient    pam_succeed_if.so service in crond quiet use_uid
+session      sufficient    pam_succeed_if.so user = root quiet
+session      requisite     pam_access.so nodefgroup
+session      required      pam_unix.so
+session      required      pam_tty_audit.so disable=* enable=root
+session      optional      pam_oddjob_mkhomedir.so silent
+session      required      pam_lastlog.so showfailed
+EOM
+              )
+            }
+          end
+        end
+  
+        context "Boolean params opposite to defaults with sssd taking precedence over ldap" do
+          let(:params){{
+            :cracklib_reject_username  => false,
+            :cracklib_gecoscheck       => false,
+            :cracklib_enforce_for_root => false,
+            :display_account_lock      => true,
+            :use_ldap                  => true,
+            :use_netgroups             => true,
+            :use_openshift             => true,
+            :use_sssd                  => true
+          }}
+
+          context 'fingerprint' do
+            let(:title){ 'fingerprint' }
+            let(:filename){ '/etc/pam.d/fingerprint-auth' }
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to create_class('oddjob::mkhomedir') }
+            it { is_expected.to contain_file(filename).with_mode('0644') }
+            it { is_expected.to contain_file("#{filename}-ac").with_ensure('absent') }
+            it { is_expected.to contain_file(filename).with_content(<<EOM
+#%PAM-1.0
+# This file managed by Puppet
+# User changes will be lost!
+auth     optional      pam_faildelay.so
+auth     required      pam_env.so
+auth     required      pam_faillock.so preauth  deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
+auth     sufficient    pam_fprintd.so
+auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     required      pam_deny.so
+
+account     required      pam_access.so accessfile=/etc/security/access.conf
+account     required      pam_unix.so broken_shadow
+account     required      pam_faillock.so
+account     [success=4 default=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+account     [success=3 default=ignore] pam_succeed_if.so service = crond quiet
+account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     requisite     pam_access.so nodefgroup
+account     [success=1 default=ignore] pam_localuser.so
+account     [default=bad success=ok system_err=ignore user_unknown=ignore] pam_sss.so
+account     required      pam_permit.so
+
+password     required      pam_deny.so
+
+session      optional      pam_keyinit.so revoke
+session      required      pam_limits.so
+-session     optional      pam_systemd.so
+session      sufficient    pam_succeed_if.so service = gdm-launch-environment quiet
+session      sufficient    pam_succeed_if.so service in crond quiet use_uid
+session      sufficient    pam_succeed_if.so user = root quiet
+session      [default=1 success=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+session      required      pam_namespace.so no_unmount_on_close
+session      [default=ignore success=1] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+session      requisite     pam_access.so nodefgroup
+session      optional      pam_sss.so
+session      required      pam_tty_audit.so disable=* enable=root
+session      optional      pam_oddjob_mkhomedir.so silent
+session      required      pam_lastlog.so showfailed
+EOM
+              )
+            }
+
+          end
+
+          context 'password' do
+            let(:title){ 'password' }
+            let(:filename){ '/etc/pam.d/password-auth' }
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to create_class('oddjob::mkhomedir') }
+            it { is_expected.to contain_file(filename).with_mode('0644') }
+            it { is_expected.to contain_file("#{filename}-ac").with_ensure('absent') }
+            it { is_expected.to contain_file(filename).with_content(<<EOM
+#%PAM-1.0
+# This file managed by Puppet
+# User changes will be lost!
+auth     optional      pam_faildelay.so
+auth     required      pam_env.so
+auth     required      pam_faillock.so preauth  deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
+auth     sufficient    pam_sss.so forward_pass
+auth     sufficient    pam_unix.so try_first_pass
+auth     [default=die] pam_faillock.so authfail deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60
+auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     required      pam_deny.so
+
+account     required      pam_access.so accessfile=/etc/security/access.conf
+account     required      pam_unix.so broken_shadow
+account     required      pam_faillock.so
+account     [success=4 default=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+account     [success=3 default=ignore] pam_succeed_if.so service = crond quiet
+account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     requisite     pam_access.so nodefgroup
+account     [success=1 default=ignore] pam_localuser.so
+account     [default=bad success=ok system_err=ignore user_unknown=ignore] pam_sss.so
+account     required      pam_permit.so
+
+password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=14 minclass=3 maxrepeat=2 maxclassrepeat=0 maxsequence=4 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1
+password     sufficient    pam_sss.so use_authtok
+password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok remember=24
+password     required      pam_deny.so
+
+session      optional      pam_keyinit.so revoke
+session      required      pam_limits.so
+-session     optional      pam_systemd.so
+session      sufficient    pam_succeed_if.so service = gdm-launch-environment quiet
+session      sufficient    pam_succeed_if.so service in crond quiet use_uid
+session      sufficient    pam_succeed_if.so user = root quiet
+session      [default=1 success=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+session      required      pam_namespace.so no_unmount_on_close
+session      [default=ignore success=1] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+session      requisite     pam_access.so nodefgroup
+session      optional      pam_sss.so
+session      required      pam_tty_audit.so disable=* enable=root
+session      optional      pam_oddjob_mkhomedir.so silent
+session      required      pam_lastlog.so showfailed
+EOM
+              )
+            }
+          end
+
+          context 'smartcard' do
+            let(:title){ 'smartcard' }
+            let(:filename){ '/etc/pam.d/smartcard-auth' }
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to create_class('oddjob::mkhomedir') }
+            it { is_expected.to contain_file(filename).with_mode('0644') }
+            it { is_expected.to contain_file("#{filename}-ac").with_ensure('absent') }
+            it { is_expected.to contain_file(filename).with_content(<<EOM
+#%PAM-1.0
+# This file managed by Puppet
+# User changes will be lost!
+auth     optional      pam_faildelay.so
+auth     required      pam_env.so
+auth     required      pam_faillock.so preauth  deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
+auth     [success=done ignore=ignore default=die] pam_pkcs11.so wait_for_card card_only
+auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     required      pam_deny.so
+
+account     required      pam_access.so accessfile=/etc/security/access.conf
+account     required      pam_unix.so broken_shadow
+account     required      pam_faillock.so
+account     [success=4 default=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+account     [success=3 default=ignore] pam_succeed_if.so service = crond quiet
+account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     requisite     pam_access.so nodefgroup
+account     [success=1 default=ignore] pam_localuser.so
+account     [default=bad success=ok system_err=ignore user_unknown=ignore] pam_sss.so
+account     required      pam_permit.so
+
+password     required      pam_pkcs11.so
+
+session      optional      pam_keyinit.so revoke
+session      required      pam_limits.so
+-session     optional      pam_systemd.so
+session      sufficient    pam_succeed_if.so service = gdm-launch-environment quiet
+session      sufficient    pam_succeed_if.so service in crond quiet use_uid
+session      sufficient    pam_succeed_if.so user = root quiet
+session      [default=1 success=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+session      required      pam_namespace.so no_unmount_on_close
+session      [default=ignore success=1] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+session      requisite     pam_access.so nodefgroup
+session      optional      pam_sss.so
+session      optional      pam_oddjob_mkhomedir.so silent
+session      required      pam_lastlog.so showfailed
+EOM
+              )
+            }
+          end
+
+          context 'system' do
+            let(:title){ 'system' }
+            let(:filename){ '/etc/pam.d/system-auth' }
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to create_class('oddjob::mkhomedir') }
+            it { is_expected.to contain_file(filename).with_mode('0644') }
+            it { is_expected.to contain_file("#{filename}-ac").with_ensure('absent') }
+            it { is_expected.to contain_file(filename).with_content(<<EOM
+#%PAM-1.0
+# This file managed by Puppet
+# User changes will be lost!
+auth     optional      pam_faildelay.so
+auth     required      pam_env.so
+auth     required      pam_faillock.so preauth  deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
+auth     sufficient    pam_sss.so forward_pass
+auth     sufficient    pam_unix.so try_first_pass
+auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     required      pam_deny.so
+
+account     required      pam_access.so accessfile=/etc/security/access.conf
+account     required      pam_unix.so broken_shadow
+account     required      pam_faillock.so
+account     [success=4 default=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+account     [success=3 default=ignore] pam_succeed_if.so service = crond quiet
+account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     requisite     pam_access.so nodefgroup
+account     [success=1 default=ignore] pam_localuser.so
+account     [default=bad success=ok system_err=ignore user_unknown=ignore] pam_sss.so
+account     required      pam_permit.so
+
+password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=14 minclass=3 maxrepeat=2 maxclassrepeat=0 maxsequence=4 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1
+password     sufficient    pam_sss.so use_authtok
+password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok remember=24
+password     required      pam_deny.so
+
+session      optional      pam_keyinit.so revoke
+session      required      pam_limits.so
+-session     optional      pam_systemd.so
+session      sufficient    pam_succeed_if.so service = gdm-launch-environment quiet
+session      sufficient    pam_succeed_if.so service in crond quiet use_uid
+session      sufficient    pam_succeed_if.so user = root quiet
+session      [default=1 success=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+session      required      pam_namespace.so no_unmount_on_close
+session      [default=ignore success=1] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+session      requisite     pam_access.so nodefgroup
+session      optional      pam_sss.so
+session      required      pam_tty_audit.so disable=* enable=root
+session      optional      pam_oddjob_mkhomedir.so silent
+session      required      pam_lastlog.so showfailed
+EOM
               )
             }
           end
         end
 
-        context "using SSSD" do
-          ['password','system'].each do |auth_type|
+        context "'password' using LDAP without SSSD and use_openshift" do
+          let(:title){ 'password' }
+          let(:filename){ "/etc/pam.d/password-auth" }
+          let(:params){{
+            :use_ldap      => true,
+            :use_openshift => true   # allows us to test non-SSSD paths
+          }}
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('oddjob::mkhomedir') }
+          it { is_expected.to contain_file(filename).with_mode('0644') }
+          it { is_expected.to contain_file("#{filename}-ac").with_ensure('absent') }
+          it { is_expected.to contain_file(filename).with_content(<<EOM
+#%PAM-1.0
+# This file managed by Puppet
+# User changes will be lost!
+auth     optional      pam_faildelay.so
+auth     required      pam_env.so
+auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
+auth     sufficient    pam_unix.so try_first_pass
+auth     sufficient    pam_ldap.so use_first_pass ignore_unknown_user ignore_authinfo_unavail
+auth     [default=die] pam_faillock.so authfail deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60
+auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     required      pam_deny.so
+
+account     [success=1]   pam_unix.so broken_shadow
+account     optional      pam_ldap.so ignore_unknown_user ignore_authinfo_unavail
+account     required      pam_faillock.so
+account     [success=3 default=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
+account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     requisite     pam_access.so nodefgroup
+account     required      pam_permit.so
+
+password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=14 minclass=3 maxrepeat=2 maxclassrepeat=0 maxsequence=4 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck reject_username enforce_for_root
+password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok remember=24
+password     sufficient    pam_ldap.so use_authtok ignore_unknown_user ignore_authinfo_unavail
+password     required      pam_deny.so
+
+session      optional      pam_keyinit.so revoke
+session      required      pam_limits.so
+-session     optional      pam_systemd.so
+session      sufficient    pam_succeed_if.so service = gdm-launch-environment quiet
+session      sufficient    pam_succeed_if.so service in crond quiet use_uid
+session      sufficient    pam_succeed_if.so user = root quiet
+session      [default=1 success=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+session      required      pam_namespace.so no_unmount_on_close
+session      [default=ignore success=1] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+session      requisite     pam_access.so nodefgroup
+session      [success=1]   pam_unix.so
+session      optional      pam_ldap.so ignore_unknown_user ignore_authinfo_unavail
+session      required      pam_tty_audit.so disable=* enable=root
+session      optional      pam_oddjob_mkhomedir.so silent
+session      required      pam_lastlog.so showfailed
+EOM
+            )
+          }
+        end
+
+        context "'system' using LDAP without SSSD and use_openshift" do
+          let(:title){ 'system' }
+          let(:filename){ "/etc/pam.d/system-auth" }
+          let(:params){{
+            :use_ldap      => true,
+            :use_openshift => true   # allows us to test non-SSSD paths
+          }}
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to create_class('oddjob::mkhomedir') }
+          it { is_expected.to contain_file(filename).with_mode('0644') }
+          it { is_expected.to contain_file("#{filename}-ac").with_ensure('absent') }
+          it { is_expected.to contain_file(filename).with_content(<<EOM
+#%PAM-1.0
+# This file managed by Puppet
+# User changes will be lost!
+auth     optional      pam_faildelay.so
+auth     required      pam_env.so
+auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
+auth     sufficient    pam_unix.so try_first_pass
+auth     sufficient    pam_ldap.so use_first_pass ignore_unknown_user ignore_authinfo_unavail
+auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     required      pam_deny.so
+
+account     [success=1]   pam_unix.so broken_shadow
+account     optional      pam_ldap.so ignore_unknown_user ignore_authinfo_unavail
+account     required      pam_faillock.so
+account     [success=3 default=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
+account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     requisite     pam_access.so nodefgroup
+account     required      pam_permit.so
+
+password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=14 minclass=3 maxrepeat=2 maxclassrepeat=0 maxsequence=4 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck reject_username enforce_for_root
+password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok remember=24
+password     sufficient    pam_ldap.so use_authtok ignore_unknown_user ignore_authinfo_unavail
+password     required      pam_deny.so
+
+session      optional      pam_keyinit.so revoke
+session      required      pam_limits.so
+-session     optional      pam_systemd.so
+session      sufficient    pam_succeed_if.so service = gdm-launch-environment quiet
+session      sufficient    pam_succeed_if.so service in crond quiet use_uid
+session      sufficient    pam_succeed_if.so user = root quiet
+session      [default=1 success=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+session      required      pam_namespace.so no_unmount_on_close
+session      [default=ignore success=1] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
+session      requisite     pam_access.so nodefgroup
+session      [success=1]   pam_unix.so
+session      optional      pam_ldap.so ignore_unknown_user ignore_authinfo_unavail
+session      required      pam_tty_audit.so disable=* enable=root
+session      optional      pam_oddjob_mkhomedir.so silent
+session      required      pam_lastlog.so showfailed
+EOM
+            )
+          }
+        end
+
+        context "Enabling pam_tty_audit for multiple users" do
+          ['password','system','fingerprint'].each do |auth_type|
             context "auth type '#{auth_type}'" do
               let(:title){ auth_type }
               let(:filename){ "/etc/pam.d/#{auth_type}-auth" }
               let(:params){{
-                :use_ldap => true,
-                :use_sssd => true
+                :tty_audit_enable => ['root', 'user1', 'user2']
               }}
 
               it { is_expected.to compile.with_all_deps }
               it { is_expected.to create_class('oddjob::mkhomedir') }
               it { is_expected.to contain_file(filename).with_mode('0644') }
               it { is_expected.to contain_file("#{filename}-ac").with_ensure('absent') }
-
               it { is_expected.to contain_file(filename).with_content(
-                /^\s*password\s+sufficient\s+pam_unix\.so/m
-                )
-              }
-              it { is_expected.to contain_file(filename).with_content(
-                /^\s*password\s+sufficient\s+pam_sss\.so.*\n\s*.+pam_unix\.so/m
-                )
-              }
-              it { is_expected.to contain_file(filename).without_content(
-                /^\s*password\s+sufficient\s+pam_ldap\.so/m
+                /^\s*session\s+required\s+pam_tty_audit\.so\s+disable=\*\s+enable=root,user1,user2/m
                 )
               }
             end
           end
         end
 
-        context "using LDAP without SSSD" do
-          ['password','system'].each do |auth_type|
+        context "Not using pam_tty_audit for any users" do
+          ['password','system','fingerprint'].each do |auth_type|
             context "auth type '#{auth_type}'" do
               let(:title){ auth_type }
               let(:filename){ "/etc/pam.d/#{auth_type}-auth" }
               let(:params){{
-                :use_ldap => true
+                :tty_audit_enable => []
               }}
 
               it { is_expected.to compile.with_all_deps }
               it { is_expected.to create_class('oddjob::mkhomedir') }
               it { is_expected.to contain_file(filename).with_mode('0644') }
               it { is_expected.to contain_file("#{filename}-ac").with_ensure('absent') }
-
-              it { is_expected.to contain_file(filename).with_content(
-                /^\s*password\s+sufficient\s+pam_unix\.so/m
-                )
-              }
               it { is_expected.to contain_file(filename).without_content(
-                /^\s*password\s+sufficient\s+pam_sss\.so/m
-                )
-              }
-              it { is_expected.to contain_file(filename).with_content(
-                /^\s*.*pam_unix\.so.*\n\s*password\s+sufficient\s+pam_ldap\.so/m
+                /^\s*session\s+required\s+pam_tty_audit\.so/m
                 )
               }
             end

--- a/templates/etc/pam.d/auth.erb
+++ b/templates/etc/pam.d/auth.erb
@@ -2,10 +2,6 @@
 # This file managed by Puppet
 # User changes will be lost!
 <%
-def td_gt_rhel5?
-  return ( ['RedHat','CentOS'].include?(@operatingsystem) && (scope.function_versioncmp([@operatingsystemmajrelease,'5']) > 0) )
-end
-
 # Build the auth section:
 # Remember: ORDER MATTERS!
 
@@ -14,15 +10,10 @@ _auth = [
   "auth     required      pam_env.so"
 ]
 
-if td_gt_rhel5?
-  _auth << "auth     required      pam_faillock.so preauth" +
-          " #{!@display_account_lock ? 'silent' : ''}" +
-          " deny=#{@deny} even_deny_root audit unlock_time=#{@unlock_time} root_unlock_time=#{@root_unlock_time}" +
-          " fail_interval=#{@fail_interval}"
-else
-  _auth << "auth     required      pam_tally2.so onerr=fail deny=#{@deny}" +
-          " audit unlock_time=#{@unlock_time} root_unlock_time=#{@root_unlock_time}"
-end
+_auth << "auth     required      pam_faillock.so preauth" +
+        " #{!@display_account_lock ? 'silent' : ''}" +
+        " deny=#{@deny} even_deny_root audit unlock_time=#{@unlock_time} root_unlock_time=#{@root_unlock_time}" +
+        " fail_interval=#{@fail_interval}"
 
 if @name == 'fingerprint'
   _auth << 'auth     sufficient    pam_fprintd.so'
@@ -38,14 +29,14 @@ if ['system','password'].include?(@name)
     _auth << 'auth     sufficient    pam_sss.so forward_pass'
     _auth << 'auth     sufficient    pam_unix.so try_first_pass'
   elsif @use_ldap
-    _auth << 'auth     sufficient  pam_unix.so try_first_pass'
-    _auth << 'auth     sufficient  pam_ldap.so use_first_pass ignore_unknown_user ignore_authinfo_unavail'
+    _auth << 'auth     sufficient    pam_unix.so try_first_pass'
+    _auth << 'auth     sufficient    pam_ldap.so use_first_pass ignore_unknown_user ignore_authinfo_unavail'
   else
-    _auth << 'auth     sufficient  pam_unix.so try_first_pass'
+    _auth << 'auth     sufficient    pam_unix.so try_first_pass'
   end
 end
 
-if td_gt_rhel5? && (@name == 'password')
+if @name == 'password'
   _auth << "auth     [default=die] pam_faillock.so authfail deny=#{@deny} even_deny_root audit unlock_time=#{@unlock_time} root_unlock_time=#{@root_unlock_time}"
 end
 
@@ -61,23 +52,19 @@ if @use_netgroups
 end
 
 if @use_ldap && !@use_sssd
-  _account << 'account     [success=1]     pam_unix.so broken_shadow'
+  _account << 'account     [success=1]   pam_unix.so broken_shadow'
   _account << 'account     optional      pam_ldap.so ignore_unknown_user ignore_authinfo_unavail'
 else
   _account << 'account     required      pam_unix.so broken_shadow'
 end
 
-if td_gt_rhel5?
-  _account << 'account     required      pam_faillock.so'
-else
-  _account << 'account     required      pam_tally2.so'
-end
+_account << 'account     required      pam_faillock.so'
 
 if @use_sssd
   if @use_openshift
     _account << 'account     [success=4 default=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user'
   end
-  _account << 'account     [success=3 default=ignore]  pam_succeed_if.so service = crond quiet'
+  _account << 'account     [success=3 default=ignore] pam_succeed_if.so service = crond quiet'
   _account << "account     sufficient    pam_succeed_if.so uid < #{@uid} quiet"
   _account << 'account     requisite     pam_access.so nodefgroup'
   _account << 'account     [success=1 default=ignore] pam_localuser.so'
@@ -86,8 +73,8 @@ else
   if @use_openshift
     _account << 'account     [success=3 default=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user'
   end
-  _account << 'account     [success=2 default=ignore]  pam_succeed_if.so service = crond quiet'
-  _account << "account     sufficient  pam_succeed_if.so uid < #{@uid} quiet"
+  _account << 'account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet'
+  _account << "account     sufficient    pam_succeed_if.so uid < #{@uid} quiet"
   _account << 'account     requisite     pam_access.so nodefgroup'
 end
 _account << 'account     required      pam_permit.so'
@@ -120,7 +107,7 @@ if ['system','password'].include?(@name)
                 " shadow try_first_pass use_authtok remember=#{@remember}"
 
   if @use_sssd
-    _password << 'password      sufficient    pam_sss.so use_authtok'
+    _password << 'password     sufficient    pam_sss.so use_authtok'
     _password << _pam_unix
   elsif @use_ldap
     _password << _pam_unix
@@ -149,7 +136,7 @@ _session = [
 
 if @use_openshift
   _session << 'session      [default=1 success=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user'
-  _session << 'session      required    pam_namespace.so no_unmount_on_close'
+  _session << 'session      required      pam_namespace.so no_unmount_on_close'
   _session << 'session      [default=ignore success=1] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user'
 end
 
@@ -162,6 +149,10 @@ elsif @use_ldap
   _session << 'session      optional      pam_ldap.so ignore_unknown_user ignore_authinfo_unavail'
 else
   _session << 'session      required      pam_unix.so'
+end
+
+if ['system','password','fingerprint'].include?(@name) and !@tty_audit_enable.empty?
+  _session << "session      required      pam_tty_audit.so disable=* enable=#{@tty_audit_enable.join(',')}"
 end
 
 _session << 'session      optional      pam_oddjob_mkhomedir.so silent'


### PR DESCRIPTION
(1) Added pam_tty_audit.so line to system-auth, password-auth and
    fingerprint-auth.  This line uses a new configuration element,
    pam::tty_audit_enable, which is an array of usernames to which
    this auditing will be applied.
(2) Fix bug in which display_account_lock variable was not available
    to auth.erb.
(3) Updated module to use new rake helper to auto-generate RPM
    .spec file.
(4) Minor cleanup
    - Remove RHEL5-related logic in auth.rb.
    - Replace deprecated ensure => 'present' with ensure => 'file'
      in access.pp and limits.pp.
    - Minor tweaks to spacing in files generated using auth.erb
    - Flesh out auth_spec.rb tests.
    - Update .puppet-lint.rc to ignore empty strings and missing
      trailing commas.  This change require 2 additional gems in
      the Gemfile.

SIMP-1017 #close
