### PR TITLE
(SIMP-1394) Update to use pam_pwhistory.so

### DIFF
--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -28,6 +28,8 @@ define pam::auth (
   $display_account_lock      = $::pam::display_account_lock,
   $fail_interval             = $::pam::fail_interval,
   $remember                  = $::pam::remember,
+  $remember_retry            = $::pam::remember_retry,
+  $remember_for_root         = $::pam::remember_for_root,
   $root_unlock_time          = $::pam::root_unlock_time,
   $rounds                    = $::pam::rounds,
   $uid                       = $::pam::uid,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,9 +125,20 @@
 #   Sets the file mode creation mask of the user home directories.
 #
 # [*remember*]
-#   The last n passwords for each user are saved in /etc/security/opasswd in order to force password
-#   change history and keep the user from alternating between the same password too frequently.
+#   The last n passwords for each user are saved in /etc/security/opasswd in
+#   order to force password change history and keep the user from alternating
+#   between the same password too frequently.
 #   Defaults to 24.
+#
+# [*remember_retry*]
+#   Type: Integer
+#   Default: 1
+#     Allow this many retries for a valid password
+#
+# [*remember_for_root*]
+#   Type: Boolean
+#   Default: true
+#     If set, also remember the last ``$remember`` passwords for the root user.
 #
 # [*root_unlock_time*]
 #   Allow access after n seconds to root account after failed attempt.
@@ -198,6 +209,8 @@ class pam (
   $display_account_lock      = false,
   $homedir_umask             = '0077',
   $remember                  = '24',
+  $remember_retry            = '1',
+  $remember_for_root         = true,
   $root_unlock_time          = '60',
   $rounds                    = '10000',
   $uid                       = '500',
@@ -233,6 +246,8 @@ class pam (
   validate_bool($display_account_lock)
   validate_umask($homedir_umask)
   validate_integer($remember)
+  validate_integer($remember_retry)
+  validate_bool($remember_for_root)
   validate_integer($root_unlock_time)
   validate_integer($rounds)
   validate_integer($uid)
@@ -314,4 +329,3 @@ class pam (
     ::pam::auth { $auth_sections: }
   }
 }
-

--- a/spec/expected/auth_spec/password-auth_default_params
+++ b/spec/expected/auth_spec/password-auth_default_params
@@ -17,7 +17,8 @@ account     requisite     pam_access.so nodefgroup
 account     required      pam_permit.so
 
 password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=14 minclass=3 maxrepeat=2 maxclassrepeat=0 maxsequence=4 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck reject_username enforce_for_root
-password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok remember=24
+password     required      pam_pwhistory.so remember=24 retry=1 enforce_for_root
+password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok
 password     required      pam_deny.so
 
 session      optional      pam_keyinit.so revoke

--- a/spec/expected/auth_spec/password-auth_ldap_openshift_multi_tty_audit
+++ b/spec/expected/auth_spec/password-auth_ldap_openshift_multi_tty_audit
@@ -20,7 +20,8 @@ account     requisite     pam_access.so nodefgroup
 account     required      pam_permit.so
 
 password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=14 minclass=3 maxrepeat=2 maxclassrepeat=0 maxsequence=4 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck reject_username enforce_for_root
-password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok remember=24
+password     required      pam_pwhistory.so remember=24 retry=1 enforce_for_root
+password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok
 password     sufficient    pam_ldap.so use_authtok ignore_unknown_user ignore_authinfo_unavail
 password     required      pam_deny.so
 

--- a/spec/expected/auth_spec/password-auth_sssd_no_tty_audit
+++ b/spec/expected/auth_spec/password-auth_sssd_no_tty_audit
@@ -23,7 +23,8 @@ account     required      pam_permit.so
 
 password     requisite     pam_cracklib.so try_first_pass difok=2 retry=10 minlen=8 minclass=7 maxrepeat=5 maxclassrepeat=4 maxsequence=6 dcredit=1 ucredit=11 lcredit=3 ocredit=9
 password     sufficient    pam_sss.so use_authtok
-password     sufficient    pam_unix.so sha512 rounds=16 shadow try_first_pass use_authtok remember=14
+password     required      pam_pwhistory.so remember=14 retry=1 enforce_for_root
+password     sufficient    pam_unix.so sha512 rounds=16 shadow try_first_pass use_authtok
 password     required      pam_deny.so
 
 session      optional      pam_keyinit.so revoke

--- a/spec/expected/auth_spec/system-auth_default_params
+++ b/spec/expected/auth_spec/system-auth_default_params
@@ -16,7 +16,8 @@ account     requisite     pam_access.so nodefgroup
 account     required      pam_permit.so
 
 password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=14 minclass=3 maxrepeat=2 maxclassrepeat=0 maxsequence=4 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck reject_username enforce_for_root
-password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok remember=24
+password     required      pam_pwhistory.so remember=24 retry=1 enforce_for_root
+password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok
 password     required      pam_deny.so
 
 session      optional      pam_keyinit.so revoke

--- a/spec/expected/auth_spec/system-auth_ldap_openshift_multi_tty_audit
+++ b/spec/expected/auth_spec/system-auth_ldap_openshift_multi_tty_audit
@@ -19,7 +19,8 @@ account     requisite     pam_access.so nodefgroup
 account     required      pam_permit.so
 
 password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=14 minclass=3 maxrepeat=2 maxclassrepeat=0 maxsequence=4 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck reject_username enforce_for_root
-password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok remember=24
+password     required      pam_pwhistory.so remember=24 retry=1 enforce_for_root
+password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok
 password     sufficient    pam_ldap.so use_authtok ignore_unknown_user ignore_authinfo_unavail
 password     required      pam_deny.so
 

--- a/spec/expected/auth_spec/system-auth_sssd_no_tty_audit
+++ b/spec/expected/auth_spec/system-auth_sssd_no_tty_audit
@@ -22,7 +22,8 @@ account     required      pam_permit.so
 
 password     requisite     pam_cracklib.so try_first_pass difok=2 retry=10 minlen=8 minclass=7 maxrepeat=5 maxclassrepeat=4 maxsequence=6 dcredit=1 ucredit=11 lcredit=3 ocredit=9
 password     sufficient    pam_sss.so use_authtok
-password     sufficient    pam_unix.so sha512 rounds=16 shadow try_first_pass use_authtok remember=14
+password     required      pam_pwhistory.so remember=14 retry=1 enforce_for_root
+password     sufficient    pam_unix.so sha512 rounds=16 shadow try_first_pass use_authtok
 password     required      pam_deny.so
 
 session      optional      pam_keyinit.so revoke

--- a/templates/etc/pam.d/auth.erb
+++ b/templates/etc/pam.d/auth.erb
@@ -103,16 +103,25 @@ if ['system','password'].include?(@name)
   end
 
   _password << _cracklib
+  _pam_pwhistory  = "password     required      pam_pwhistory.so remember=#{@remember} retry=#{@remember_retry}"
+
+  if @remember_for_root
+    _pam_pwhistory << ' enforce_for_root'
+  end
+
   _pam_unix = "password     sufficient    pam_unix.so sha512 rounds=#{@rounds}" +
-                " shadow try_first_pass use_authtok remember=#{@remember}"
+                ' shadow try_first_pass use_authtok'
 
   if @use_sssd
     _password << 'password     sufficient    pam_sss.so use_authtok'
+    _password << _pam_pwhistory
     _password << _pam_unix
   elsif @use_ldap
+    _password << _pam_pwhistory
     _password << _pam_unix
     _password << 'password     sufficient    pam_ldap.so use_authtok ignore_unknown_user ignore_authinfo_unavail'
   else
+    _password << _pam_pwhistory
     _password << _pam_unix
   end
 end


### PR DESCRIPTION
This is a fix for the SELinux changes that occured in EL7 with the
/etc/security/opasswd file that prevented the changing of local user
passwords.

SIMP-1394 #close
