### PR TITLE
(SIMP-1450) Update to use new 'simpcat'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.1.0-0
+- Updated to use the version of 'simpcat' that does not conflict with
+  'puppetlabs/concat'.
+
 * Thu Aug 25 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.2.5-0
 - Update to pam_pwhistory.so to fix local user login failures due to SELinux
   policy updates affecting /etc/security/opasswd in EL7.

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,6 +1,6 @@
 Requires: pupmod-simp-compliance_markup
 Requires: pupmod-simp-oddjob >= 1.0.0-0
 Requires: pupmod-simp-rsync >= 2.0.0-0
-Requires: pupmod-simp-simpcat >= 2.0.0-0
+Requires: pupmod-simp-simpcat >= 6.0.0-0
 Requires: pupmod-simp-sssd >= 2.0.0-0
 Obsoletes: pupmod-pam-test >= 0.0.1

--- a/manifests/access.pp
+++ b/manifests/access.pp
@@ -14,7 +14,7 @@
 class pam::access {
   include '::pam'
 
-  concat_build { 'pam_access':
+  simpcat_build { 'pam_access':
     target        => '/etc/security/access.conf',
     order         => '*.access',
     squeeze_blank => true,
@@ -26,7 +26,7 @@ class pam::access {
     owner     => 'root',
     group     => 'root',
     mode      => '0644',
-    subscribe => Concat_build['pam_access'],
+    subscribe => Simpcat_build['pam_access'],
     audit     => content
   }
 

--- a/manifests/access/manage.pp
+++ b/manifests/access/manage.pp
@@ -114,5 +114,5 @@ define pam::access::manage (
     $content = "# ${l_comment}\n${permission} : ${users} : ${l_origins}\n"
   }
 
-  concat_fragment { "pam_access+${order}.${l_name}.access": content => $content }
+  simpcat_fragment { "pam_access+${order}.${l_name}.access": content => $content }
 }

--- a/manifests/limits.pp
+++ b/manifests/limits.pp
@@ -8,7 +8,7 @@
 class pam::limits {
   include '::pam'
 
-  concat_build { 'pam_limits':
+  simpcat_build { 'pam_limits':
     order   => ['*.limit'],
     target  => '/etc/security/limits.conf',
     require => Package['pam']
@@ -19,7 +19,7 @@ class pam::limits {
     owner     => 'root',
     group     => 'root',
     mode      => '0640',
-    subscribe => Concat_build['pam_limits'],
+    subscribe => Simpcat_build['pam_limits'],
     audit     => content
   }
 }

--- a/manifests/limits/add.pp
+++ b/manifests/limits/add.pp
@@ -61,7 +61,7 @@ define pam::limits::add (
 
   $l_name = regsubst($name,'/','_')
 
-  concat_fragment { "pam_limits+${order}.${l_name}.limit":
+  simpcat_fragment { "pam_limits+${order}.${l_name}.limit":
     content => "${domain}\t${type}\t${item}\t${value}\n"
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-pam",
-  "version": "4.2.5",
+  "version": "5.0.0",
   "author":  "simp",
   "summary": "A SIMP puppet module for managing pam",
   "license": "Apache-2.0",
@@ -12,6 +12,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.9.0"
+    },
+    {
+      "name": "simp/simpcat",
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp/simplib",

--- a/spec/classes/access_spec.rb
+++ b/spec/classes/access_spec.rb
@@ -8,13 +8,13 @@ describe 'pam::access' do
         let(:facts){ facts }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_build('pam_access').with({
+        it { is_expected.to create_simpcat_build('pam_access').with({
             :target         => '/etc/security/access.conf',
             :squeeze_blank  => true,
           })
         }
-        it { is_expected.to create_concat_build('pam_access').that_requires('Package[pam]') }
-        it { is_expected.to create_file('/etc/security/access.conf').that_subscribes_to('Concat_build[pam_access]') }
+        it { is_expected.to create_simpcat_build('pam_access').that_requires('Package[pam]') }
+        it { is_expected.to create_file('/etc/security/access.conf').that_subscribes_to('Simpcat_build[pam_access]') }
         it { is_expected.to create_pam__access__manage('default_deny').with({
             :permission => '-',
             :users      => 'ALL',

--- a/spec/classes/limits_conf.rb
+++ b/spec/classes/limits_conf.rb
@@ -8,9 +8,9 @@ describe 'pam::limits' do
         let(:facts){ facts }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_build('pam_limits').with_target('/etc/security/limits.conf') }
-        it { is_expected.to create_concat_build('pam_limits').that_requires('Package[pam]') }
-        it { is_expected.to create_file('/etc/security/limits.conf').that_subscribes_to('Concat_build[pam_limits]') }
+        it { is_expected.to create_simpcat_build('pam_limits').with_target('/etc/security/limits.conf') }
+        it { is_expected.to create_simpcat_build('pam_limits').that_requires('Package[pam]') }
+        it { is_expected.to create_file('/etc/security/limits.conf').that_subscribes_to('Simpcat_build[pam_limits]') }
       end
     end
   end

--- a/spec/defines/access/manage_spec.rb
+++ b/spec/defines/access/manage_spec.rb
@@ -16,7 +16,7 @@ describe 'pam::access::manage' do
 
         it { is_expected.to compile.with_all_deps }
 
-        it { is_expected.to create_concat_fragment("pam_access+#{params[:order]}.#{title}.access").with_content(<<-EOM.gsub(/^\s+/,'')
+        it { is_expected.to create_simpcat_fragment("pam_access+#{params[:order]}.#{title}.access").with_content(<<-EOM.gsub(/^\s+/,'')
           + : #{params[:users]} : #{params[:origins].join(' ')}
           EOM
         )}
@@ -29,7 +29,7 @@ describe 'pam::access::manage' do
             :comment => "foo\nbar\nbaz"
           }}
 
-          it { is_expected.to create_concat_fragment("pam_access+#{params[:order]}.#{title}.access").with_content(<<-EOM.gsub(/^\s+/,'')
+          it { is_expected.to create_simpcat_fragment("pam_access+#{params[:order]}.#{title}.access").with_content(<<-EOM.gsub(/^\s+/,'')
             # foo
             # bar
             # baz

--- a/spec/defines/limits/add_spec.rb
+++ b/spec/defines/limits/add_spec.rb
@@ -18,7 +18,7 @@ describe 'pam::limits::add' do
 
         it { is_expected.to compile.with_all_deps }
 
-        it { is_expected.to create_concat_fragment("pam_limits+#{params[:order]}.#{title}.limit").with_content(
+        it { is_expected.to create_simpcat_fragment("pam_limits+#{params[:order]}.#{title}.limit").with_content(
           /#{Regexp.escape(params[:domain])}\s#{params[:type]}\s#{params[:item]}\s#{params[:value]}/
         )}
       end


### PR DESCRIPTION
Updated to use the version of 'simpcat' that does not conflict with
'puppetlabs/concat'.

SIMP-1450 #comment Update to use deconflicted 'simpcat'
SIMP-843 #comment Deconflicted 'pam'
