### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,6 +1,11 @@
-Requires: pupmod-simp-compliance_markup
+Obsoletes: pupmod-pam-test >= 0.0.1
+Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
+Requires: pupmod-puppetlabs-stdlib >= 4.9.0-0
+Requires: pupmod-simp-compliance_markup < 2.0.0-0
+Requires: pupmod-simp-compliance_markup >= 1.0.1-0
 Requires: pupmod-simp-oddjob >= 1.0.0-0
 Requires: pupmod-simp-rsync >= 2.0.0-0
 Requires: pupmod-simp-simpcat >= 2.0.0-0
+Requires: pupmod-simp-simplib < 2.0.0-0
+Requires: pupmod-simp-simplib >= 1.3.1-0
 Requires: pupmod-simp-sssd >= 2.0.0-0
-Obsoletes: pupmod-pam-test >= 0.0.1

--- a/metadata.json
+++ b/metadata.json
@@ -1,25 +1,28 @@
 {
-  "name":    "simp-pam",
-  "version": "4.2.5",
-  "author":  "simp",
+  "name": "simp-pam",
+  "version": "4.2.6",
+  "author": "simp",
   "summary": "A SIMP puppet module for managing pam",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-pam",
+  "source": "https://github.com/simp/pupmod-simp-pam",
   "project_page": "https://github.com/simp/pupmod-simp-pam",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp", "pam" ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "pam"
+  ],
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.9.0"
+      "version_requirement": ">= 4.9.0 < 5.0.0"
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.3.1 < 2.0.0"
     },
     {
       "name": "simp/compliance_markup",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.0.1 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-pam`
SIMP-1613 #close