### PR TITLE
(SIMP-1692) Point fixtures to `5.X` branches

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,12 +1,20 @@
 ---
 fixtures:
   repositories:
-    compliance_markup: "https://github.com/simp/pupmod-simp-compliance_markup"
-    oddjob: "https://github.com/simp/pupmod-simp-oddjob"
-    simpcat: "https://github.com/simp/pupmod-simp-simpcat"
-    simplib: "https://github.com/simp/pupmod-simp-simplib"
+    compliance_markup:
+      repo: https://github.com/simp/pupmod-simp-compliance_markup
+      branch: 5.X
+    oddjob:
+      repo: https://github.com/simp/pupmod-simp-oddjob
+      branch: 5.X
+    simpcat:
+      repo: https://github.com/simp/pupmod-simp-simpcat
+      branch: 5.X
+    simplib:
+      repo: https://github.com/simp/pupmod-simp-simplib
+      branch: 5.X
     stdlib:
-      repo: "https://github.com/simp/puppetlabs-stdlib"
-      branch: "simp-master"
+      branch: 5.X
+      repo: https://github.com/simp/puppetlabs-stdlib
   symlinks:
     pam: "#{source_dir}"


### PR DESCRIPTION
This commit marks the transition of mainline SIMP development away from
4.x/5.x.  From this point on, the `master` branch will be used to target SIMP
6.x.

This commit updates `fixtures.yml` to reference the newly-created `5.X` branch
in each `simp/` repository.

SIMP-1692 #comment updated `.fixtures.yml` in pam