### PR TITLE
(SIMP-768) Add methods for adding content to PAM

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,3 +2,5 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-80chars-check
+--no-trailing_comma-check
+--no-empty_string_assignment-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Nov 30 2016 Nick Miller <nick.miller@onyxpoint.com> - 5.0.1-0
+- Added a generic content option to replace all templated PAM configurations
+  - Setting use_templates to false will enable them
+
 * Wed Nov 23 2016 Jeanne Greulich <jgreulich.simp@onyxpoint.com> - 5.0.0-0
 - update requirement versions
 

--- a/manifests/wheel.pp
+++ b/manifests/wheel.pp
@@ -1,31 +1,34 @@
-# _Description_
-#
 # Enable wheel restrictions for su access.
 #
-class pam::wheel (
-# _Variables_
-#
-# $wheel_group
+# @param wheel_group [String]
 #     What group should be the 'wheel' equivalent. Set to the traditional
 #     'wheel' by default.
-    $wheel_group = 'wheel',
-# $root_only
+#
+# @param root_only [Boolean]
 #     Set this if you only want to make this effective when su'ing to root.
-    $root_only = false,
-# $use_openshift
+#
+# @param use_openshift [Boolean]
 #    Whether or not to configure things in such a way that the
 #    openshift_origin puppet code is compatible.
-    $use_openshift = pick($::pam::use_openshift,false)
+#
+class pam::wheel (
+  String $wheel_group    = 'wheel',
+  Boolean $root_only     = false,
+  Boolean $use_openshift = pick($::pam::use_openshift, false),
+  Boolean $use_templates = $::pam::use_templates,
+  String $su_content     = $::pam::su_content
 ) inherits ::pam {
-  validate_string($wheel_group)
-  validate_bool($root_only)
-  validate_bool($use_openshift)
 
-
+  if $use_templates {
+    $_su_content = template('pam/etc/pam.d/su.erb')
+  }
+  else {
+    $_su_content = $su_content
+  }
   file { '/etc/pam.d/su':
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    content => template('pam/etc/pam.d/su.erb')
+    content => $_su_content
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pam",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing pam",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -7,20 +7,29 @@ describe 'pam' do
       context "on #{os}" do
         let(:facts){ facts }
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_file('/etc/pam.d').with_mode('0644') }
-        it { is_expected.to contain_file('/etc/pam.d/other').with_content(<<-EOM.gsub(/^\s+/,'')
-            auth    required    pam_warn.so
-            account    required    pam_warn.so
-            password    required    pam_warn.so
-            session    required    pam_warn.so
-            auth    required    pam_deny.so
-            account    required    pam_deny.so
-            password    required    pam_deny.so
-            session    required    pam_deny.so
-            EOM
-          )
-        }
+        context '/etc/pam.d/other with default values' do
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_file('/etc/pam.d').with_mode('0644') }
+          it { is_expected.to contain_file('/etc/pam.d/other').with_content(<<-EOM.gsub(/^\s+/,'')
+              auth    required    pam_warn.so
+              account    required    pam_warn.so
+              password    required    pam_warn.so
+              session    required    pam_warn.so
+              auth    required    pam_deny.so
+              account    required    pam_deny.so
+              password    required    pam_deny.so
+              session    required    pam_deny.so
+              EOM
+            )
+          }
+        end
+        context '/etc/pam.d/other with use_templates => false' do
+          let(:params) {{
+            :use_templates => false,
+            :other_content => 'this is valid pam other configuration, I promise'
+          }}
+          it { is_expected.to contain_file('/etc/pam.d/other').with_content('this is valid pam other configuration, I promise') }
+        end
 
         it { is_expected.to contain_package('pam') }
         it { is_expected.to contain_package('pam_pkcs11') }

--- a/spec/classes/wheel_spec.rb
+++ b/spec/classes/wheel_spec.rb
@@ -37,6 +37,14 @@ describe 'pam::wheel' do
           it { is_expected.not_to create_file('/etc/pam.d/su').with_content(/root_only/) }
           it { is_expected.to create_file('/etc/pam.d/su').with_content(/oo-trap/) }
         end
+
+        context 'with $::pam::use_templates => false' do
+          let(:params) {{
+            :use_templates => false,
+            :su_content    => 'this is valid pam su configuration, I promise'
+          }}
+          it { is_expected.to create_file('/etc/pam.d/su').with_content('this is valid pam su configuration, I promise') }
+        end
       end
     end
   end

--- a/spec/defines/auth_spec.rb
+++ b/spec/defines/auth_spec.rb
@@ -40,6 +40,26 @@ describe 'pam::auth' do
           end
         end
 
+        context 'Generate file using content params' do
+          let(:params) {{
+            :use_templates            => false,
+            :fingerprint_auth_content => 'this is valid pam fingerprint_auth configuration, I promise',
+            :system_auth_content      => 'this is valid pam system_auth configuration, I promise',
+            :password_auth_content    => 'this is valid pam password_auth configuration, I promise',
+            :smartcard_auth_content   => 'this is valid pam smartcard_auth configuration, I promise'
+          }}
+          ['fingerprint', 'password', 'smartcard', 'system'].each do |auth_type|
+            context "auth type '#{auth_type}'" do
+              let(:title){ auth_type }
+              let(:filename){ "/etc/pam.d/#{auth_type}-auth" }
+              let(:file_content) { get_expected("#{auth_type}-auth_custom_content").chomp! }
+
+              it_should_behave_like "a pam.d config file generator"
+              it { is_expected.to contain_file(filename).with_content(file_content) }
+            end
+          end
+        end
+
         context 'Generate file with SSSD taking precedence over LDAP and no TTY auditing' do
           # In this context, we will also verify the logic to deliver config to
           # auth.erb works for all config parameters, by setting these parameters

--- a/spec/expected/auth_spec/fingerprint-auth_custom_content
+++ b/spec/expected/auth_spec/fingerprint-auth_custom_content
@@ -1,0 +1,1 @@
+this is valid pam fingerprint_auth configuration, I promise

--- a/spec/expected/auth_spec/password-auth_custom_content
+++ b/spec/expected/auth_spec/password-auth_custom_content
@@ -1,0 +1,1 @@
+this is valid pam password_auth configuration, I promise

--- a/spec/expected/auth_spec/smartcard-auth_custom_content
+++ b/spec/expected/auth_spec/smartcard-auth_custom_content
@@ -1,0 +1,1 @@
+this is valid pam smartcard_auth configuration, I promise

--- a/spec/expected/auth_spec/system-auth_custom_content
+++ b/spec/expected/auth_spec/system-auth_custom_content
@@ -1,0 +1,1 @@
+this is valid pam system_auth configuration, I promise


### PR DESCRIPTION
- Added a generic content option to replace all templated PAM
  configurations
  - Setting use_templates to false will enable them

SIMP-768 #close