### PR TITLE
(SIMP-2557) Add default value pam::access::rule::origins

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * Tue Jan 17 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.0.0-0
 - Added feature to add pam::access::manage resources from hiera
+- Set a default value for origins to simp_options::trusted_nets
 
 * Thu Jan 12 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-0
 - Changed the following for the SSG:

--- a/manifests/access/rule.pp
+++ b/manifests/access/rule.pp
@@ -37,7 +37,7 @@
 #     order      => 1000
 #   }
 #
-# @aaram name [String]
+# @param name [String]
 #   A unique name for the resource
 #
 # @param comment
@@ -46,7 +46,7 @@
 # @param permission
 #   If +, grant access. If -, revoke access
 #
-# users
+# @param users
 #   The users, groups, or netgroups to allow access to the system.
 #
 #   Syntax:
@@ -74,7 +74,7 @@
 #
 define pam::access::rule (
   Array[String]         $users,
-  Array[String]         $origins,
+  Simplib::Netlist      $origins    = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] }),
   Enum['+','-']         $permission = '+',
   Optional[String]      $comment    = undef,
   Integer[1,9999999999] $order      = 1000

--- a/metadata.json
+++ b/metadata.json
@@ -48,11 +48,11 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": "4.x"
+      "version_requirement": "> 4.7"
     },
     {
       "name": "pe",
-      "version_requirement": ">= 2016.2.0"
+      "version_requirement": ">= 2016.4.0"
     }
   ],
   "data_provider": "hiera"


### PR DESCRIPTION
Set pam::access::rule::origins to default to simp_options::trusted_nets

SIMP-2557 #close