### PR TITLE
(SIMP-3613) pam: Update to concat 3.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Aug 18 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.4-0
+- Add concat dependency to metadata.json
+- Update concat dependency in build/rpm_metadata/requires
+
 * Tue May 23 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.3-0
 - Fixed docs in pam::limits::rule
 - Update puppet requirement in metadata.json

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,5 +1,5 @@
 Obsoletes: pupmod-pam-test >= 0.0.1
-Requires: pupmod-puppetlabs-concat < 3.0.0-0
+Requires: pupmod-puppetlabs-concat < 4.0.0-0
 Requires: pupmod-puppetlabs-concat >= 2.2.0-0
 Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
 Requires: pupmod-puppetlabs-stdlib >= 4.13.1-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pam",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing pam",
   "license": "Apache-2.0",
@@ -12,6 +12,10 @@
     "pam"
   ],
   "dependencies": [
+    {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 2.2.0 < 4.0.0"
+    },
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.1 < 5.0.0"


### PR DESCRIPTION
- Update concat version. concat 3.0.0 is fully backward compatible with 2.x.
- Add concat dependency to metadata.json