### PR TITLE
(SIMP-3613) pam: Pin concat to 3.0.0 in .fixtures.yml

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,10 @@
 ---
 fixtures:
   repositories:
-    concat: https://github.com/simp/puppetlabs-concat
+    concat:
+      # master is at 4.0.1, but we are bound to < 4.0.0 in our metadata.json
+      repo: https://github.com/simp/puppetlabs-concat
+      ref: 3.0.0
     oddjob: https://github.com/simp/pupmod-simp-oddjob
     simplib: https://github.com/simp/pupmod-simp-simplib
     simp_options: https://github.com/simp/pupmod-simp-simp_options


### PR DESCRIPTION
Pin concat to 3.0.0 in .fixtures.yml, as metadata.json bounds
concat to < 4.0.0.