### PR TITLE
(SIMP-1246) Enable pam_tty_audit for sudo

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Sep 22 2017 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.1.0-0
+- Enable pam_tty_audit for sudo
+
 * Fri Aug 18 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.4-0
 - Add concat dependency to metadata.json
 - Update concat dependency in build/rpm_metadata/requires

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -282,6 +282,28 @@ class pam (
         $_other_content = template('pam/etc/pam.d/other.erb')
       }
 
+      $_pamd_sudo_content = epp('pam/etc/pam.d/sudo', {
+        'pam_module_path' => 'system-auth',
+        'force_revoke'    => false,
+        'tty_audit_users' => $tty_audit_users,
+      })
+
+      $_pamd_sudo_i_content = epp('pam/etc/pam.d/sudo', {
+        'pam_module_path' => 'sudo',
+        'force_revoke'    => true,
+        'tty_audit_users' => $tty_audit_users,
+      })
+
+      file { ['/etc/pam.d/sudo','/etc/pam.d/sudo-i']:
+        ensure  => 'file',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+      }
+      File['/etc/pam.d/sudo']{ content => $_pamd_sudo_content }
+      File['/etc/pam.d/sudo-i']{ content => $_pamd_sudo_i_content }
+
+
       file { '/etc/pam.d/other':
         ensure  => 'file',
         owner   => 'root',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pam",
-  "version": "6.0.4",
+  "version": "6.1.0",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing pam",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -7,6 +7,85 @@ describe 'pam' do
       context "on #{os}" do
         let(:facts){ facts }
 
+        context '/etc/pam.d/sudo and /etc/pam.d/sudo-i' do
+          context 'with default values' do
+            it { is_expected.to contain_file('/etc/pam.d/sudo').with_content(<<-EOM.gsub(/^\s+/,'')
+                #%PAM-1.0
+                auth include system-auth
+                account include system-auth
+                password include system-auth
+                session optional pam_keyinit.so revoke
+                session required pam_limits.so
+                session required pam_tty_audit.so disable=* enable=root open_only
+                EOM
+              )
+            }
+            it { is_expected.to contain_file('/etc/pam.d/sudo-i').with_content(<<-EOM.gsub(/^\s+/,'')
+                #%PAM-1.0
+                auth include sudo
+                account include sudo
+                password include sudo
+                session optional pam_keyinit.so force revoke
+                session required pam_limits.so
+                session required pam_tty_audit.so disable=* enable=root open_only
+                EOM
+              )
+            }
+          end
+          context 'with empty tty_audit_users' do
+            let(:params) {{
+              :tty_audit_users => []
+            }}
+            it { is_expected.to contain_file('/etc/pam.d/sudo').with_content(<<-EOM.gsub(/^\s+/,'')
+                #%PAM-1.0
+                auth include system-auth
+                account include system-auth
+                password include system-auth
+                session optional pam_keyinit.so revoke
+                session required pam_limits.so
+                EOM
+              )
+            }
+            it { is_expected.to contain_file('/etc/pam.d/sudo-i').with_content(<<-EOM.gsub(/^\s+/,'')
+                #%PAM-1.0
+                auth include sudo
+                account include sudo
+                password include sudo
+                session optional pam_keyinit.so force revoke
+                session required pam_limits.so
+                EOM
+              )
+            }
+          end
+          context 'with multiple tty_audit_users' do
+            let(:params) {{
+              :tty_audit_users => ['root','foo','bar']
+            }}
+            it { is_expected.to contain_file('/etc/pam.d/sudo').with_content(<<-EOM.gsub(/^\s+/,'')
+                #%PAM-1.0
+                auth include system-auth
+                account include system-auth
+                password include system-auth
+                session optional pam_keyinit.so revoke
+                session required pam_limits.so
+                session required pam_tty_audit.so disable=* enable=root,foo,bar open_only
+                EOM
+              )
+            }
+            it { is_expected.to contain_file('/etc/pam.d/sudo-i').with_content(<<-EOM.gsub(/^\s+/,'')
+                #%PAM-1.0
+                auth include sudo
+                account include sudo
+                password include sudo
+                session optional pam_keyinit.so force revoke
+                session required pam_limits.so
+                session required pam_tty_audit.so disable=* enable=root,foo,bar open_only
+                EOM
+              )
+            }
+          end
+        end
+
         context '/etc/pam.d/other with default values' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_file('/etc/pam.d').with_mode('0644') }

--- a/templates/etc/pam.d/sudo.epp
+++ b/templates/etc/pam.d/sudo.epp
@@ -1,0 +1,16 @@
+<%- |
+      Enum['system-auth','sudo'] $pam_module_path,
+      Boolean                    $force_revoke,
+      Array                      $tty_audit_users,
+      Array[String]              $pam_types = ['auth','account','password']
+|
+-%>
+#%PAM-1.0
+<% $pam_types.each |$pam_type| { -%>
+<%= $pam_type %> include <%= $pam_module_path %>
+<%- } -%>
+session optional pam_keyinit.so <%= if $force_revoke { 'force ' } %>revoke
+session required pam_limits.so
+<%- unless empty($tty_audit_users) { -%>
+session required pam_tty_audit.so disable=* enable=<%= $tty_audit_users.join(',') %> open_only
+<%- } -%>


### PR DESCRIPTION
This commit manages the files `/etc/pam.d/sudo` and `/etc/pam.d/sudo-i`
and (when pam_tty_audit contains users) ensures that it contains the
following line:

```
session required pam_tty_audit.so disable=* enable=root open_only
```

SIMP-1246 #close
