### PR TITLE
(SIMP-3892) Use login_defs.uid_min by default

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,97 +1,97 @@
 #
 ---
-puppet-syntax: 
+puppet-syntax:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.1
-  script: 
+  script:
     - bundle install
     - bundle exec rake syntax
-puppet-lint: 
+puppet-lint:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.1
-  script: 
+  script:
     - bundle install
     - bundle exec rake lint
-puppet-metadata: 
+puppet-metadata:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.1
-  script: 
+  script:
     - bundle install
     - bundle exec rake metadata
 unit-test-ruby-2.1:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.1
-  script: 
+  script:
     - bundle install
     - bundle exec rake spec
 unit-test-ruby-2.2:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.2
   allow_failure: true
-  script: 
+  script:
     - bundle install
     - bundle exec rake spec
 unit-test-ruby-2.3:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.3
   allow_failure: true
-  script: 
+  script:
     - bundle install
     - bundle exec rake spec
 
 # For PE LTS Support
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
-puppet4.7-syntax: 
+puppet4.7-syntax:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.1
-  script: 
+  script:
     - PUPPET_VERSION=4.7 bundle install
     - PUPPET_VERSION=4.7 bundle exec rake syntax
 unit-test-puppet4.7-ruby-2.1:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.1
-  script: 
+  script:
     - PUPPET_VERSION=4.7 bundle install
     - PUPPET_VERSION=4.7 bundle exec rake spec
 unit-test-puppet4.7-ruby-2.2:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.2
   allow_failure: true
-  script: 
+  script:
     - PUPPET_VERSION=4.7 bundle install
     - PUPPET_VERSION=4.7 bundle exec rake spec
 unit-test-puppet4.7-ruby-2.3:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.3
   allow_failure: true
-  script: 
+  script:
     - PUPPET_VERSION=4.7 bundle install
     - PUPPET_VERSION=4.7 bundle exec rake spec
 
-acceptance-test: 
+acceptance-test:
   stage: test
-  tags: 
+  tags:
     - beaker
-  script: 
+  script:
     - bundle install --no-binstubs --path=vendor
-    - bundle exec rake acceptance
+    - bundle exec rake beaker:suites

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,7 +2,7 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-140chars-check
---no-empty_string-check
+--no-empty_string_assignment-check
 --no-trailing_comma-check
 # This is here because the code can't handle lookups in parameters and we have
 # a LOT of those

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,48 +8,81 @@
 # PE 2017.2   4.10  2.1.9  TBD
 ---
 language: ruby
-sudo: false
 cache: bundler
-before_script:
-  - bundle update
+sudo: false
+
 bundler_args: --without development system_tests --path .vendor
-before_install: rm Gemfile.lock || true
-script:
-  - bundle exec rake test
+
 notifications:
   email: false
-rvm:
-  - 2.1.9
-env:
-  global:
-    - STRICT_VARIABLES=yes
-  matrix:
-    - PUPPET_VERSION="~> 4.8.2" FORGE_PUBLISH=true
-    - PUPPET_VERSION="~> 4.10.0"
-    - PUPPET_VERSION="~> 4.9.2"
-    - PUPPET_VERSION="~> 4.7.0"
-matrix:
-  fast_finish: true
 
-before_deploy:
-  - 'bundle exec rake metadata_lint'
-  - 'bundle exec rake clobber'
-  - 'bundle exec rake spec_clean'
-  - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
-  - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
-deploy:
-  - provider: puppetforge
-    user: simp
-    password:
-        secure: "B/wFlcjh1dYP6uUZBvpbEFPuhgojzCpy2Ebwb2KHEbAlltMzD5HWIeguCWdBTkKLJGiPsX4HpBq9UXQpPu1ZFb4a0dP5oyskNufon8/zozYY3IC23I3I/C2hCkyknxQK8abVW9/JLVKTX/SEX019IFoe7r/cfy3e1qUEehPV//DCdKohzmUfITa8dBE8lgwHK2e7acbhpEJ1j9C2XqnydKFKETHUOidzW4vduM6Lk0/O6ymVHEa/VNWqGpaLjhAkL3zsIOk9B8UR3wQT6sEwP0UQNi3sQyMQm2ECA0zPh3C8/YBdmQDcrrqd9Xq45hoHVZbwJI1MzA+j7yNQIfly7EqXjnvM7yhUJcMBbkb+tKdU0cnELrMgcPaKnDpqI+UpWNwmQUFbiW7R6729YSO4PVcVPOWfgZVdTqX0iuf+66SwaxTHa1DOajs6DGMIx79nPcbUwbvHiJyLyqNNYr8dI6B76ks15ReeSaoDxU1dVc/5VoSHxD6LzNKuv/PDwmRxrpXFtcj8G0fBj2qiWN9Dio/CpnhYYxnvhcg+BKsmV738yADDwJKct7riSDm/J3Z2iG8VNIHFGaH2xVy/GGC9npYay5isH9hHMKiwL4BrA75f5X95Hu+Oqoi8Uw0u18zqSgUC7y8TW9rx5izHCtxIqUhVC7Eu252t3ow75yuEkJw="
-    on:
-      tags: true
+addons:
+  apt:
+    packages:
+      - rpm
+
+before_install:
+  - rm -f Gemfile.lock
+
+jobs:
+  include:
+    - stage: spec
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5"
+      script:
+        - bundle exec rake check:dot_underscore
+        - bundle exec rake check:test_file
+        - bundle exec rake pkg:check_version
+        - bundle exec rake metadata_lint
+        - bundle exec rake compare_latest_tag
+        - bundle exec rake lint
+        - bundle exec puppet module build
+
+    - stage: spec
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
       rvm: 2.1.9
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
-  - provider: releases
-    api_key:
-        secure: "gSNAacMcIL3cOUMgKKD/OHGtMxPHMgCNd1In4eBWGHk182CJHiHlvpGKv2YdyFlegfM+1meyQW2mkVvm+o5+p3PkCUUPW3aAHgfRRVcpOKEuDMQvcJOa0SCnDG/FozpFV4+xMnZa2quHPZshS5DWXUgzqRhhrnKeBavLaOiFi01jPmQDGidDVHH/TmXCL45b81YwpJ/fbsp23ZLqvoDDDD4X2f3RStCCFFtpPfLpBV1k3CWF44cnEq3/lCeUBt11bSeg+uSj7XKJF8dvl8w4cX2j7E/8UobwtQswYOoRWrKzbHRsYn/0ICW79YTIaKNnr49b+6kOcz7Nhk5NDzNa0sFgeRv9NPWcWdQUvqOVL7Z1DIGYfn5yLK2a9CuMXJEF0u17lovfU+X4wcckFxNaPWRLKhmUZzA90YFKLufa6Dg+coRL45ex4sEPKcfyV0lV/V/5ShfoIEdRJ2VMVsdyO8YiYWrnjtCOknl1VEEekkGg+/8WCJPPmrDFYcTp1p+ju/koi27pE6YjiU7qZkRDaM7lLMcYNYvuB7RcW7DwzUrNtchIbIm+YdB9xgIkFD8HJVBbrp7yKFC5Ed/7iP37fuyWZ7KICvyWoaiEz+tEsIUMODJpbZs+XOipGWf1GmcCKUZvXA+rZD3RQuYfheEipdPF2Y/juwv8jSOs6hmRVb0="
-    skip_cleanup: true
-    on:
-      tags: true
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.10.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.9.2"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.7.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: deploy
+      rvm: 2.4.1
+      script:
+        - true
+      before_deploy:
+        - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
+        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+
+      deploy:
+        - provider: releases
+          api_key:
+            secure: "gSNAacMcIL3cOUMgKKD/OHGtMxPHMgCNd1In4eBWGHk182CJHiHlvpGKv2YdyFlegfM+1meyQW2mkVvm+o5+p3PkCUUPW3aAHgfRRVcpOKEuDMQvcJOa0SCnDG/FozpFV4+xMnZa2quHPZshS5DWXUgzqRhhrnKeBavLaOiFi01jPmQDGidDVHH/TmXCL45b81YwpJ/fbsp23ZLqvoDDDD4X2f3RStCCFFtpPfLpBV1k3CWF44cnEq3/lCeUBt11bSeg+uSj7XKJF8dvl8w4cX2j7E/8UobwtQswYOoRWrKzbHRsYn/0ICW79YTIaKNnr49b+6kOcz7Nhk5NDzNa0sFgeRv9NPWcWdQUvqOVL7Z1DIGYfn5yLK2a9CuMXJEF0u17lovfU+X4wcckFxNaPWRLKhmUZzA90YFKLufa6Dg+coRL45ex4sEPKcfyV0lV/V/5ShfoIEdRJ2VMVsdyO8YiYWrnjtCOknl1VEEekkGg+/8WCJPPmrDFYcTp1p+ju/koi27pE6YjiU7qZkRDaM7lLMcYNYvuB7RcW7DwzUrNtchIbIm+YdB9xgIkFD8HJVBbrp7yKFC5Ed/7iP37fuyWZ7KICvyWoaiEz+tEsIUMODJpbZs+XOipGWf1GmcCKUZvXA+rZD3RQuYfheEipdPF2Y/juwv8jSOs6hmRVb0="
+          skip_cleanup: true
+          on:
+            tags: true
+            condition: '($SKIP_FORGE_PUBLISH != true)'
+        - provider: puppetforge
+          user: simp
+          password:
+            secure: "B/wFlcjh1dYP6uUZBvpbEFPuhgojzCpy2Ebwb2KHEbAlltMzD5HWIeguCWdBTkKLJGiPsX4HpBq9UXQpPu1ZFb4a0dP5oyskNufon8/zozYY3IC23I3I/C2hCkyknxQK8abVW9/JLVKTX/SEX019IFoe7r/cfy3e1qUEehPV//DCdKohzmUfITa8dBE8lgwHK2e7acbhpEJ1j9C2XqnydKFKETHUOidzW4vduM6Lk0/O6ymVHEa/VNWqGpaLjhAkL3zsIOk9B8UR3wQT6sEwP0UQNi3sQyMQm2ECA0zPh3C8/YBdmQDcrrqd9Xq45hoHVZbwJI1MzA+j7yNQIfly7EqXjnvM7yhUJcMBbkb+tKdU0cnELrMgcPaKnDpqI+UpWNwmQUFbiW7R6729YSO4PVcVPOWfgZVdTqX0iuf+66SwaxTHa1DOajs6DGMIx79nPcbUwbvHiJyLyqNNYr8dI6B76ks15ReeSaoDxU1dVc/5VoSHxD6LzNKuv/PDwmRxrpXFtcj8G0fBj2qiWN9Dio/CpnhYYxnvhcg+BKsmV738yADDwJKct7riSDm/J3Z2iG8VNIHFGaH2xVy/GGC9npYay5isH9hHMKiwL4BrA75f5X95Hu+Oqoi8Uw0u18zqSgUC7y8TW9rx5izHCtxIqUhVC7Eu252t3ow75yuEkJw="
+          on:
+            tags: true
+            rvm: 2.4.1
+            condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Dec 13 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.1-0
+- Set the minimum UID allowed onto the system to the default defined in
+  /etc/login.defs or 1000 if not otherwise defined
+
 * Fri Sep 22 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.1.0-0
 - Changed password checking from pam_cracklib.so to pam_pwquality.so for EL7
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -255,7 +255,7 @@ class pam (
   Boolean                        $remember_for_root         = true,
   Integer[0]                     $root_unlock_time          = 60,
   Integer[0]                     $rounds                    = 10000,
-  Integer[0]                     $uid                       = 500,
+  Integer[0]                     $uid                       = simplib::lookup('simp_options::uid::min', { 'default_value' => pick(fact('login_defs.uid_min'), 1000) }),
   Integer[0]                     $unlock_time               = 900,
   Integer[0]                     $fail_interval             = 900,
   Boolean                        $preserve_ac               = false,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pam",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing pam",
   "license": "Apache-2.0",
@@ -25,12 +25,8 @@
       "version_requirement": ">= 2.0.0 < 3.0.0"
     },
     {
-      "name": "simp/simpcat",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
-    },
-    {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.10.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/expected/auth_spec/cracklib-fingerprint-auth_default_params
+++ b/spec/expected/auth_spec/cracklib-fingerprint-auth_default_params
@@ -5,13 +5,13 @@ auth     optional      pam_faildelay.so
 auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_fprintd.so
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     required      pam_permit.so
 

--- a/spec/expected/auth_spec/cracklib-fingerprint-auth_sssd_openshift_multi_tty_audit
+++ b/spec/expected/auth_spec/cracklib-fingerprint-auth_sssd_openshift_multi_tty_audit
@@ -5,14 +5,14 @@ auth     optional      pam_faildelay.so
 auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_fprintd.so
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=4 default=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
 account     [success=3 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     [success=1 default=ignore] pam_localuser.so
 account     [default=bad success=ok system_err=ignore user_unknown=ignore] pam_sss.so

--- a/spec/expected/auth_spec/cracklib-password-auth_default_params
+++ b/spec/expected/auth_spec/cracklib-password-auth_default_params
@@ -6,13 +6,13 @@ auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_unix.so try_first_pass
 auth     [default=die] pam_faillock.so authfail deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     required      pam_permit.so
 

--- a/spec/expected/auth_spec/cracklib-password-auth_sssd_openshift_multi_tty_audit
+++ b/spec/expected/auth_spec/cracklib-password-auth_sssd_openshift_multi_tty_audit
@@ -7,14 +7,14 @@ auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audi
 auth     sufficient    pam_sss.so forward_pass
 auth     sufficient    pam_unix.so try_first_pass
 auth     [default=die] pam_faillock.so authfail deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=4 default=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
 account     [success=3 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     [success=1 default=ignore] pam_localuser.so
 account     [default=bad success=ok system_err=ignore user_unknown=ignore] pam_sss.so

--- a/spec/expected/auth_spec/cracklib-password-separator-0
+++ b/spec/expected/auth_spec/cracklib-password-separator-0
@@ -6,13 +6,13 @@ auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_unix.so try_first_pass
 auth     [default=die] pam_faillock.so authfail deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=! nodefgroup
 account     required      pam_permit.so
 

--- a/spec/expected/auth_spec/cracklib-password-separator-1
+++ b/spec/expected/auth_spec/cracklib-password-separator-1
@@ -6,13 +6,13 @@ auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_unix.so try_first_pass
 auth     [default=die] pam_faillock.so authfail deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     required      pam_permit.so
 

--- a/spec/expected/auth_spec/cracklib-password-separator-2
+++ b/spec/expected/auth_spec/cracklib-password-separator-2
@@ -6,13 +6,13 @@ auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_unix.so try_first_pass
 auth     [default=die] pam_faillock.so authfail deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=@ nodefgroup
 account     required      pam_permit.so
 

--- a/spec/expected/auth_spec/cracklib-password-separator-false
+++ b/spec/expected/auth_spec/cracklib-password-separator-false
@@ -6,13 +6,13 @@ auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_unix.so try_first_pass
 auth     [default=die] pam_faillock.so authfail deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so nodefgroup
 account     required      pam_permit.so
 

--- a/spec/expected/auth_spec/cracklib-smartcard-auth_default_params
+++ b/spec/expected/auth_spec/cracklib-smartcard-auth_default_params
@@ -5,13 +5,13 @@ auth     optional      pam_faildelay.so
 auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     [success=done ignore=ignore default=die] pam_pkcs11.so wait_for_card card_only
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     required      pam_permit.so
 

--- a/spec/expected/auth_spec/cracklib-smartcard-auth_sssd_openshift_multi_tty_audit
+++ b/spec/expected/auth_spec/cracklib-smartcard-auth_sssd_openshift_multi_tty_audit
@@ -5,14 +5,14 @@ auth     optional      pam_faildelay.so
 auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     [success=done ignore=ignore default=die] pam_pkcs11.so wait_for_card card_only
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=4 default=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
 account     [success=3 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     [success=1 default=ignore] pam_localuser.so
 account     [default=bad success=ok system_err=ignore user_unknown=ignore] pam_sss.so

--- a/spec/expected/auth_spec/cracklib-system-auth_default_params
+++ b/spec/expected/auth_spec/cracklib-system-auth_default_params
@@ -5,13 +5,13 @@ auth     optional      pam_faildelay.so
 auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_unix.so try_first_pass
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     required      pam_permit.so
 

--- a/spec/expected/auth_spec/cracklib-system-auth_sssd_openshift_multi_tty_audit
+++ b/spec/expected/auth_spec/cracklib-system-auth_sssd_openshift_multi_tty_audit
@@ -6,14 +6,14 @@ auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_sss.so forward_pass
 auth     sufficient    pam_unix.so try_first_pass
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=4 default=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
 account     [success=3 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     [success=1 default=ignore] pam_localuser.so
 account     [default=bad success=ok system_err=ignore user_unknown=ignore] pam_sss.so

--- a/spec/expected/auth_spec/pwquality-fingerprint-auth_default_params
+++ b/spec/expected/auth_spec/pwquality-fingerprint-auth_default_params
@@ -5,13 +5,13 @@ auth     optional      pam_faildelay.so
 auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_fprintd.so
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     required      pam_permit.so
 

--- a/spec/expected/auth_spec/pwquality-fingerprint-auth_sssd_openshift_multi_tty_audit
+++ b/spec/expected/auth_spec/pwquality-fingerprint-auth_sssd_openshift_multi_tty_audit
@@ -5,14 +5,14 @@ auth     optional      pam_faildelay.so
 auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_fprintd.so
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=4 default=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
 account     [success=3 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     [success=1 default=ignore] pam_localuser.so
 account     [default=bad success=ok system_err=ignore user_unknown=ignore] pam_sss.so

--- a/spec/expected/auth_spec/pwquality-password-auth_default_params
+++ b/spec/expected/auth_spec/pwquality-password-auth_default_params
@@ -6,13 +6,13 @@ auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_unix.so try_first_pass
 auth     [default=die] pam_faillock.so authfail deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     required      pam_permit.so
 

--- a/spec/expected/auth_spec/pwquality-password-auth_sssd_openshift_multi_tty_audit
+++ b/spec/expected/auth_spec/pwquality-password-auth_sssd_openshift_multi_tty_audit
@@ -7,14 +7,14 @@ auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audi
 auth     sufficient    pam_sss.so forward_pass
 auth     sufficient    pam_unix.so try_first_pass
 auth     [default=die] pam_faillock.so authfail deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=4 default=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
 account     [success=3 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     [success=1 default=ignore] pam_localuser.so
 account     [default=bad success=ok system_err=ignore user_unknown=ignore] pam_sss.so

--- a/spec/expected/auth_spec/pwquality-password-separator-0
+++ b/spec/expected/auth_spec/pwquality-password-separator-0
@@ -6,13 +6,13 @@ auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_unix.so try_first_pass
 auth     [default=die] pam_faillock.so authfail deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=! nodefgroup
 account     required      pam_permit.so
 

--- a/spec/expected/auth_spec/pwquality-password-separator-1
+++ b/spec/expected/auth_spec/pwquality-password-separator-1
@@ -6,13 +6,13 @@ auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_unix.so try_first_pass
 auth     [default=die] pam_faillock.so authfail deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     required      pam_permit.so
 

--- a/spec/expected/auth_spec/pwquality-password-separator-2
+++ b/spec/expected/auth_spec/pwquality-password-separator-2
@@ -6,13 +6,13 @@ auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_unix.so try_first_pass
 auth     [default=die] pam_faillock.so authfail deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=@ nodefgroup
 account     required      pam_permit.so
 

--- a/spec/expected/auth_spec/pwquality-password-separator-false
+++ b/spec/expected/auth_spec/pwquality-password-separator-false
@@ -6,13 +6,13 @@ auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_unix.so try_first_pass
 auth     [default=die] pam_faillock.so authfail deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so nodefgroup
 account     required      pam_permit.so
 

--- a/spec/expected/auth_spec/pwquality-smartcard-auth_default_params
+++ b/spec/expected/auth_spec/pwquality-smartcard-auth_default_params
@@ -5,13 +5,13 @@ auth     optional      pam_faildelay.so
 auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     [success=done ignore=ignore default=die] pam_pkcs11.so wait_for_card card_only
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     required      pam_permit.so
 

--- a/spec/expected/auth_spec/pwquality-smartcard-auth_sssd_openshift_multi_tty_audit
+++ b/spec/expected/auth_spec/pwquality-smartcard-auth_sssd_openshift_multi_tty_audit
@@ -5,14 +5,14 @@ auth     optional      pam_faildelay.so
 auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     [success=done ignore=ignore default=die] pam_pkcs11.so wait_for_card card_only
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=4 default=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
 account     [success=3 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     [success=1 default=ignore] pam_localuser.so
 account     [default=bad success=ok system_err=ignore user_unknown=ignore] pam_sss.so

--- a/spec/expected/auth_spec/pwquality-system-auth_default_params
+++ b/spec/expected/auth_spec/pwquality-system-auth_default_params
@@ -5,13 +5,13 @@ auth     optional      pam_faildelay.so
 auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_unix.so try_first_pass
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=2 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     required      pam_permit.so
 

--- a/spec/expected/auth_spec/pwquality-system-auth_sssd_openshift_multi_tty_audit
+++ b/spec/expected/auth_spec/pwquality-system-auth_sssd_openshift_multi_tty_audit
@@ -6,14 +6,14 @@ auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 even_deny_root audit unlock_time=900 root_unlock_time=60 fail_interval=900
 auth     sufficient    pam_sss.so forward_pass
 auth     sufficient    pam_unix.so try_first_pass
-auth     requisite     pam_succeed_if.so uid >= 500 quiet
+auth     requisite     pam_succeed_if.so uid >= 1000 quiet
 auth     required      pam_deny.so
 
 account     required      pam_unix.so broken_shadow
 account     required      pam_faillock.so
 account     [success=4 default=ignore] pam_succeed_if.so quiet shell = /usr/bin/oo-trap-user
 account     [success=3 default=ignore] pam_succeed_if.so service = crond quiet
-account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
 account     requisite     pam_access.so listsep=, nodefgroup
 account     [success=1 default=ignore] pam_localuser.so
 account     [default=bad success=ok system_err=ignore user_unknown=ignore] pam_sss.so


### PR DESCRIPTION
Change the minimum allowed UID to that defined in /etc/login.defs by
default or 1000 if nothing else is defined.

SIMP-4192 #comment Add consistency for the global min_uid settings