### PR TITLE
(SIMP-4679) Convert to Hiera 5 for compliance test

### DIFF
--- a/spec/acceptance/suites/compliance/00_default_spec.rb
+++ b/spec/acceptance/suites/compliance/00_default_spec.rb
@@ -21,16 +21,15 @@ compliance_markup::enforcement:
     context 'when enforcing the STIG' do
       let(:hiera_yaml) { <<-EOM
 ---
-:backends:
-  - yaml
-  - simp_compliance_enforcement
-:yaml:
-  :datadir: "#{hiera_datadir(host)}"
-:simp_compliance_enforcement:
-  :datadir: "#{hiera_datadir(host)}"
-:hierarchy:
-  - default
-:logger: console
+version: 5
+hierarchy:
+  - name: Common
+    path: default.yaml
+  - name: Compliance
+    lookup_key: compliance_markup::enforcement
+defaults:
+  data_hash: yaml_data
+  datadir: "#{hiera_datadir(host)}"
   EOM
       }
 


### PR DESCRIPTION
Discovered that Puppet 4.10.4+ breaks the compliance engine Hiera 3
backend.