### PR TITLE
(SIMP-5478) limits.conf ordering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :test do
   gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0.0')
+  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.1.0')
   gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.2', '< 6.0'])
   gem 'facterdb'
 end

--- a/manifests/limits.pp
+++ b/manifests/limits.pp
@@ -9,6 +9,7 @@ class pam::limits {
     owner          => 'root',
     group          => 'root',
     mode           => '0640',
+    order          => 'numeric',
     ensure_newline => true,
     warn           => true
   }

--- a/spec/acceptance/suites/compliance/00_default_spec.rb
+++ b/spec/acceptance/suites/compliance/00_default_spec.rb
@@ -24,7 +24,7 @@ compliance_markup::enforcement:
 version: 5
 hierarchy:
   - name: Common
-    path: default.yaml
+    path: common.yaml
   - name: Compliance
     lookup_key: compliance_markup::enforcement
 defaults:

--- a/spec/acceptance/suites/default/20_check_limits_order_spec.rb
+++ b/spec/acceptance/suites/default/20_check_limits_order_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper_acceptance'
+
+test_name 'pam class'
+
+describe 'pam class' do
+  let(:manifest) {
+    <<-EOS
+      include '::pam'
+      include '::pam::limits'
+
+      pam::limits::rule { 'limit_wild_nproc_soft':
+        domains => ['*'],
+        type    => 'soft',
+        item    => 'nproc',
+        value   => 50,
+        order   => 1,
+      }
+
+      pam::limits::rule { 'limit_test_nproc_soft':
+        domains => ['test'],
+        type    => 'soft',
+        item    => 'nproc',
+        value   => 20,
+        order   => 9,
+      }
+
+      pam::limits::rule { 'limit_test_nproc_hard':
+        domains => ['test'],
+        type    => 'hard',
+        item    => 'nproc',
+        value   => 50,
+        order   => 10,
+      }
+    EOS
+  }
+
+  let(:limits_content) { File.read('spec/expected/limits_acceptance/limits_conf_numeric') }
+
+  hosts.each do |host|
+    context "on #{host}" do
+      context 'default parameters' do
+        it 'should work with no errors' do
+           apply_manifest_on(host, manifest, :catch_failures => true)
+        end
+
+        it 'should be idempotent' do
+          apply_manifest_on(host, manifest, {:catch_changes => true})
+        end
+
+        describe file('/etc/security/limits.conf') do
+          it { should be_file }
+          its(:content) { should eq(limits_content) }
+        end
+      end
+    end
+  end
+end

--- a/spec/expected/limits_acceptance/limits_conf_numeric
+++ b/spec/expected/limits_acceptance/limits_conf_numeric
@@ -1,0 +1,4 @@
+# This file is managed by Puppet. DO NOT EDIT.
+*	soft	nproc	50
+test	soft	nproc	20
+test	hard	nproc	50


### PR DESCRIPTION
This updates the order value for the concat resource of /etc/security/limits.conf
to 'numeric' to ensure proper ordering of rule fragments.

Also updates simp-rspec-facts to version that includes OEL facts.

#Fixes SIMP-5478