### PR TITLE
(SIMP-6108) Allow users to manage access.conf permissions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 * Fri Mar 15 2019 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 6.4.0-0
 - Added pam::access::access_file_mode parameter to allow users to manage
   access.conf file permissions
+- Updated lower bound on stdlib to 4.22.0 to add Filemode strong type support
 
 * Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.3.1-0
 - Expanded the upper limit of the concat and stdlib Puppet module versions

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Mar 15 2019 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 6.4.0-0
+- Added pam::access::access_file_mode parameter to allow users to manage
+  access.conf file permissions
+
 * Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.3.1-0
 - Expanded the upper limit of the concat and stdlib Puppet module versions
 - Updated a URL in the README.md

--- a/manifests/access.pp
+++ b/manifests/access.pp
@@ -24,13 +24,17 @@
 #       baddude:
 #         permission: '-'
 #
+# @param access_file_mode
+#   File mode for /etc/security/access.conf
+#
 # @see access.conf(5)
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class pam::access (
-  Boolean        $default_deny = true,
-  Optional[Hash] $users        = undef
+  Boolean        $default_deny     = true,
+  Optional[Hash] $users            = undef,
+  String         $access_file_mode = '0644',
 ){
 
   if $default_deny {
@@ -40,7 +44,7 @@ class pam::access (
   concat { '/etc/security/access.conf':
     owner          => 'root',
     group          => 'root',
-    mode           => '0644',
+    mode           => $access_file_mode,
     ensure_newline => true,
     warn           => true
   }

--- a/manifests/access.pp
+++ b/manifests/access.pp
@@ -32,9 +32,9 @@
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class pam::access (
-  Boolean        $default_deny     = true,
-  Optional[Hash] $users            = undef,
-  String         $access_file_mode = '0644',
+  Boolean          $default_deny     = true,
+  Optional[Hash]   $users            = undef,
+  Stdlib::Filemode $access_file_mode = '0644',
 ){
 
   if $default_deny {

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 6.0.0"
+      "version_requirement": ">= 4.22.0 < 6.0.0"
     },
     {
       "name": "simp/oddjob",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pam",
-  "version": "6.3.1",
+  "version": "6.4.0",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing pam",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Added pam::access::access_file_mode parameter to allow users to manage
  access.conf file permissions

SIMP-6108 #close