### PR TITLE
(SIMP-7528) Disable authselect

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Fri Feb 28 2020 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.7.0-0
+- Ignore authconfig disable on EL8. Authconfig was replaced with authselect
+  and authselect does not overwrite settings unless you select --force
+  option.
+
 * Tue Dec 24 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.7.0-0
 - Add EL8 support
 - Remove installation of pam_pkcs11 and fprintd-pam by default since they not

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -83,25 +83,25 @@ class pam::config {
     ;
   }
 
-  if ($pam::disable_authconfig == true) {
+  if ($facts['os']['release']['major'] <= '7') and ($pam::disable_authconfig == true) {
     # Replace authconfig and authconfig-tui with a no-op script
     # so that those tools can't be used to modify PAM.
-    file { '/usr/local/sbin/simp_authconfig.sh':
-      ensure  => 'file',
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0755',
-      content => file("${module_name}/simp_authconfig.sh")
-    }
+      file { '/usr/local/sbin/simp_authconfig.sh':
+        ensure  => 'file',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0755',
+        content => file("${module_name}/simp_authconfig.sh")
+      }
 
-    file { [
-      '/usr/sbin/authconfig',
-      '/usr/sbin/authconfig-tui'
-      ]:
-      ensure  => 'link',
-      target  => '/usr/local/sbin/simp_authconfig.sh',
-      require => File['/usr/local/sbin/simp_authconfig.sh']
-    }
+      file { [
+        '/usr/sbin/authconfig',
+        '/usr/sbin/authconfig-tui'
+        ]:
+        ensure  => 'link',
+        target  => '/usr/local/sbin/simp_authconfig.sh',
+        require => File['/usr/local/sbin/simp_authconfig.sh']
+      }
   }
 
   if ! empty($pam::auth_sections) { ::pam::auth { $pam::auth_sections: }}

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -20,21 +20,30 @@ describe 'pam class' do
           apply_manifest_on(host, manifest, {:catch_changes => true})
         end
 
-        it 'should replace authconfig and authconfi-tui links' do
-          result = on(host, 'ls -l /usr/sbin/authconfig')
-          expect(result.stdout).to match(/authconfig -> \/usr\/local\/sbin\/simp_authconfig.sh/)
+        case  host[:platform]
+        when /el-[67]-x86_64/
+          it 'should replace authconfig and authconfi-tui links' do
+            result = on(host, 'ls -l /usr/sbin/authconfig')
+            expect(result.stdout).to match(/authconfig -> \/usr\/local\/sbin\/simp_authconfig.sh/)
 
-          result = on(host, 'ls -l /usr/sbin/authconfig-tui')
-          expect(result.stdout).to match(/authconfig-tui -> \/usr\/local\/sbin\/simp_authconfig.sh/)
-        end
+            result = on(host, 'ls -l /usr/sbin/authconfig-tui')
+            expect(result.stdout).to match(/authconfig-tui -> \/usr\/local\/sbin\/simp_authconfig.sh/)
+          end
 
-        it 'authconfig and authconfig-tui should have no affect on PAM configuration' do
-          on(host, '/usr/sbin/authconfig --update')
-          # verify Puppet detects no changes to PAM configuration after authconfig is run
-          apply_manifest_on(host, manifest, {:catch_changes => true})
+          it 'authconfig and authconfig-tui should have no affect on PAM configuration' do
+            on(host, '/usr/sbin/authconfig --update')
+            # verify Puppet detects no changes to PAM configuration after authconfig is run
+            apply_manifest_on(host, manifest, {:catch_changes => true})
 
-          # verify Puppet detects no changes to PAM configuration after authconfig-tui is run
-          on(host, '/usr/sbin/authconfig-tui --update')
+            # verify Puppet detects no changes to PAM configuration after authconfig-tui is run
+            on(host, '/usr/sbin/authconfig-tui --update')
+            apply_manifest_on(host, manifest, {:catch_changes => true})
+          end
+        else
+          result = on(host, 'ls -l /usr/sbin/authconfig', :accept_all_exit_codes => true)
+          expect(result.stdout).to match(/No such file or directory/)
+          result = on(host,'/usr/bin/authselect select sssd', :accept_all_exit_codes => true)
+          expect(result.stdout).to match(/[error] Refusing to activate profile/)
           apply_manifest_on(host, manifest, {:catch_changes => true})
         end
       end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -99,19 +99,26 @@ describe 'pam' do
           )
         }
 
-        it {
-          project_dir = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
-          expected = IO.read(File.join(project_dir, 'files', 'simp_authconfig.sh'))
-          is_expected.to contain_file('/usr/local/sbin/simp_authconfig.sh').with_content(expected)
-        }
-
-        [ '/usr/sbin/authconfig', '/usr/sbin/authconfig-tui'].each do |file|
-          it { is_expected.to contain_file(file).with( {
-              :ensure  => 'link',
-              :target  => '/usr/local/sbin/simp_authconfig.sh',
-              :require => 'File[/usr/local/sbin/simp_authconfig.sh]'
-            } )
+        if os_facts[:os][:release][:major] <= '7'
+          it {
+            project_dir = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
+            expected = IO.read(File.join(project_dir, 'files', 'simp_authconfig.sh'))
+            is_expected.to contain_file('/usr/local/sbin/simp_authconfig.sh').with_content(expected)
           }
+
+          [ '/usr/sbin/authconfig', '/usr/sbin/authconfig-tui'].each do |file|
+            it { is_expected.to contain_file(file).with( {
+                :ensure  => 'link',
+                :target  => '/usr/local/sbin/simp_authconfig.sh',
+                :require => 'File[/usr/local/sbin/simp_authconfig.sh]'
+              } )
+            }
+          end
+        else
+          it { is_expected.to_not contain_file('/usr/local/sbin/simp_authconfig.sh')}
+          [ '/usr/sbin/authconfig', '/usr/sbin/authconfig-tui'].each do |file|
+            it { is_expected.to_not contain_file(file)}
+          end
         end
 
         it { is_expected.to contain_pam__auth('fingerprint') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -138,6 +138,7 @@ RSpec.configure do |c|
     Puppet[:environmentpath] = @spec_global_env_temp
     Puppet[:user] = Etc.getpwuid(Process.uid).name
     Puppet[:group] = Etc.getgrgid(Process.gid).name
+    Puppet[:digest_algorithm] = 'sha256'
 
     # sanitize hieradata
     if defined?(hieradata)


### PR DESCRIPTION
- authselect is used in place of authconfig on EL8.  This
  fix disables authselect if the disable_authconfig boolean
  is set on EL8
- Update spec_helpers to run on FIPS

SIMP-7528 #close
SIMP-7580 #close
SIMP-7581 #close
SIMP-7377 #close