### PR TITLE
(SIMP-7605) EL8 bug: can't set local user password

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Wed Mar 25 2020 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.7.1-0
+- Moved the pam_unix.so check before the pam_sss.so check in the password
+  section of the auth files otherwise it returns an "authentication token
+  manipulation" error and local passwords can not be changed.
+
 * Fri Feb 28 2020 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.7.0-0
 - Ignore authconfig disable on EL8. Authconfig was replaced with authselect
   and authselect does not overwrite settings unless you select --force

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pam",
-  "version": "6.7.0",
+  "version": "6.7.1",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing pam",
   "license": "Apache-2.0",

--- a/spec/expected/auth_spec/cracklib-password-auth_sssd_no_tty_audit
+++ b/spec/expected/auth_spec/cracklib-password-auth_sssd_no_tty_audit
@@ -22,8 +22,8 @@ account     required      pam_permit.so
 
 password     requisite     pam_cracklib.so retry=10 minlen=8 minclass=7 maxrepeat=5 difok=2 maxsequence=6 maxclassrepeat=4 dcredit=1 ucredit=11 lcredit=3 ocredit=9
 password     required      pam_pwhistory.so use_authtok remember=14 retry=1 enforce_for_root
-password     sufficient    pam_sss.so use_authtok
 password     sufficient    pam_unix.so sha512 rounds=16 shadow try_first_pass use_authtok
+password     sufficient    pam_sss.so use_authtok
 password     required      pam_deny.so
 
 session      optional      pam_keyinit.so revoke

--- a/spec/expected/auth_spec/cracklib-password-auth_sssd_openshift_multi_tty_audit
+++ b/spec/expected/auth_spec/cracklib-password-auth_sssd_openshift_multi_tty_audit
@@ -23,8 +23,8 @@ account     required      pam_permit.so
 
 password     requisite     pam_cracklib.so retry=3 enforce_for_root reject_username minlen=15 minclass=3 maxrepeat=2 difok=4 maxsequence=4 maxclassrepeat=3 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck
 password     required      pam_pwhistory.so use_authtok remember=24 retry=1 enforce_for_root
-password     sufficient    pam_sss.so use_authtok
 password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok
+password     sufficient    pam_sss.so use_authtok
 password     required      pam_deny.so
 
 session      optional      pam_keyinit.so revoke

--- a/spec/expected/auth_spec/cracklib-system-auth_sssd_no_tty_audit
+++ b/spec/expected/auth_spec/cracklib-system-auth_sssd_no_tty_audit
@@ -22,8 +22,8 @@ account     required      pam_permit.so
 
 password     requisite     pam_cracklib.so retry=10 minlen=8 minclass=7 maxrepeat=5 difok=2 maxsequence=6 maxclassrepeat=4 dcredit=1 ucredit=11 lcredit=3 ocredit=9
 password     required      pam_pwhistory.so use_authtok remember=14 retry=1 enforce_for_root
-password     sufficient    pam_sss.so use_authtok
 password     sufficient    pam_unix.so sha512 rounds=16 shadow try_first_pass use_authtok
+password     sufficient    pam_sss.so use_authtok
 password     required      pam_deny.so
 
 session      optional      pam_keyinit.so revoke

--- a/spec/expected/auth_spec/cracklib-system-auth_sssd_openshift_multi_tty_audit
+++ b/spec/expected/auth_spec/cracklib-system-auth_sssd_openshift_multi_tty_audit
@@ -23,8 +23,8 @@ account     required      pam_permit.so
 
 password     requisite     pam_cracklib.so retry=3 enforce_for_root reject_username minlen=15 minclass=3 maxrepeat=2 difok=4 maxsequence=4 maxclassrepeat=3 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck
 password     required      pam_pwhistory.so use_authtok remember=24 retry=1 enforce_for_root
-password     sufficient    pam_sss.so use_authtok
 password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok
+password     sufficient    pam_sss.so use_authtok
 password     required      pam_deny.so
 
 session      optional      pam_keyinit.so revoke

--- a/spec/expected/auth_spec/pwquality-password-auth_sssd_no_tty_audit
+++ b/spec/expected/auth_spec/pwquality-password-auth_sssd_no_tty_audit
@@ -22,8 +22,8 @@ account     required      pam_permit.so
 
 password     requisite     pam_pwquality.so retry=10
 password     required      pam_pwhistory.so use_authtok remember=14 retry=1 enforce_for_root
-password     sufficient    pam_sss.so use_authtok
 password     sufficient    pam_unix.so sha512 rounds=16 shadow try_first_pass use_authtok
+password     sufficient    pam_sss.so use_authtok
 password     required      pam_deny.so
 
 session      optional      pam_keyinit.so revoke

--- a/spec/expected/auth_spec/pwquality-password-auth_sssd_openshift_multi_tty_audit
+++ b/spec/expected/auth_spec/pwquality-password-auth_sssd_openshift_multi_tty_audit
@@ -23,8 +23,8 @@ account     required      pam_permit.so
 
 password     requisite     pam_pwquality.so retry=3 enforce_for_root reject_username
 password     required      pam_pwhistory.so use_authtok remember=24 retry=1 enforce_for_root
-password     sufficient    pam_sss.so use_authtok
 password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok
+password     sufficient    pam_sss.so use_authtok
 password     required      pam_deny.so
 
 session      optional      pam_keyinit.so revoke

--- a/spec/expected/auth_spec/pwquality-system-auth_sssd_no_tty_audit
+++ b/spec/expected/auth_spec/pwquality-system-auth_sssd_no_tty_audit
@@ -22,8 +22,8 @@ account     required      pam_permit.so
 
 password     requisite     pam_pwquality.so retry=10
 password     required      pam_pwhistory.so use_authtok remember=14 retry=1 enforce_for_root
-password     sufficient    pam_sss.so use_authtok
 password     sufficient    pam_unix.so sha512 rounds=16 shadow try_first_pass use_authtok
+password     sufficient    pam_sss.so use_authtok
 password     required      pam_deny.so
 
 session      optional      pam_keyinit.so revoke

--- a/spec/expected/auth_spec/pwquality-system-auth_sssd_openshift_multi_tty_audit
+++ b/spec/expected/auth_spec/pwquality-system-auth_sssd_openshift_multi_tty_audit
@@ -23,8 +23,8 @@ account     required      pam_permit.so
 
 password     requisite     pam_pwquality.so retry=3 enforce_for_root reject_username
 password     required      pam_pwhistory.so use_authtok remember=24 retry=1 enforce_for_root
-password     sufficient    pam_sss.so use_authtok
 password     sufficient    pam_unix.so sha512 rounds=10000 shadow try_first_pass use_authtok
+password     sufficient    pam_sss.so use_authtok
 password     required      pam_deny.so
 
 session      optional      pam_keyinit.so revoke

--- a/templates/etc/pam.d/auth.epp
+++ b/templates/etc/pam.d/auth.epp
@@ -158,8 +158,8 @@ password     requisite     pam_<%= $password_check_backend %>.so retry=<%= $crac
 <%   $_pam_unix = "password     sufficient    pam_unix.so ${hash_algorithm} rounds=${rounds} shadow try_first_pass use_authtok" -%>
 <%   if $sssd { -%>
 <%= $_pam_pwhistory %>
-password     sufficient    pam_sss.so use_authtok
 <%= $_pam_unix %>
+password     sufficient    pam_sss.so use_authtok
 <%   } else { -%>
 <%= $_pam_pwhistory %>
 <%= $_pam_unix %>


### PR DESCRIPTION
- moved pam_unix.so check before pam_sss.so check in the
  password section of the auth files.  It returns an
  "authentication token manipulation" error  on el8
  if pam_sss.so is checked before pam_unix.

SIMP-7605 #close