### PR TITLE
(SIMP-9408) GLCI & GHA release workflow fixes

### DIFF
--- a/.github/workflows/pr_glci_cleanup.yml
+++ b/.github/workflows/pr_glci_cleanup.yml
@@ -7,7 +7,7 @@
 #
 #             NOTICE: **This file is maintained with puppetsync**
 #
-# This file is updated automatically as part of a puppet module baseline.
+# This file is updated automatically as part of a standardized asset baseline.
 #
 # The next baseline sync will overwrite any local changes to this file!
 #

--- a/.github/workflows/pr_glci_manual.yml
+++ b/.github/workflows/pr_glci_manual.yml
@@ -3,7 +3,7 @@
 #
 #             NOTICE: **This file is maintained with puppetsync**
 #
-# This file is updated automatically as part of a puppet module baseline.
+# This file is updated automatically as part of a standardized asset baseline.
 #
 # The next baseline sync will overwrite any local changes to this file!
 #

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           ruby-version: ${{matrix.puppet.ruby_version}}
           bundler-cache: true
-      - run: 'command -v rpm || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:'
+      - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
 
 #  dump_contexts:

--- a/.github/workflows/tag_deploy.yml
+++ b/.github/workflows/tag_deploy.yml
@@ -35,6 +35,7 @@ env:
 jobs:
   releng-checks:
     name: "RELENG checks"
+    if: github.repository_owner == 'simp'
     runs-on: ubuntu-18.04
     steps:
       - name: "Assert '${{ github.ref }}' is a tag"
@@ -57,6 +58,7 @@ jobs:
   create-github-release:
     name: Deploy GitHub Release
     needs: [ releng-checks ]
+    if: github.repository_owner == 'simp'
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout code
@@ -100,6 +102,7 @@ jobs:
   deploy-to-puppet-forge:
     name: Deploy PuppetForge Release
     needs: [ releng-checks ]
+    if: github.repository_owner == 'simp'
     runs-on: ubuntu-18.04
     env:
       PUPPETFORGE_API_TOKEN: ${{ secrets.PUPPETFORGE_API_TOKEN }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ variables:
       - '.vendor'
   before_script:
     # Print important environment variables that may affect this job
-    - 'ruby -e "puts %(\n\n), %q(=)*80, %(\nSIMP-relevant Environment Variables:\n\n#{e=ENV.keys.grep(/^PUPPET|^SIMP|^BEAKER|MATRIX/); pad=((e.map{|x| x.size}.max||0)+1); e.map{|v| %(    * #{%(#{v}:).ljust(pad)} #{39.chr + ENV[v] + 39.chr}\n)}.join}\n),  %q(=)*80, %(\n\n)"'
+    - 'ruby -e "puts %(\n\n), %q(=)*80, %(\nSIMP-relevant Environment Variables:\n\n#{e=ENV.keys.grep(/^PUPPET|^SIMP|^BEAKER|MATRIX/); pad=((e.map{|x| x.size}.max||0)+1); e.map{|v| %(    * #{%(#{v}:).ljust(pad)} #{39.chr + ENV[v] + 39.chr}\n)}.join}\n),  %q(=)*80, %(\n\n)" || :'
 
     - echo -e "\e[0Ksection_start:`date +%s`:before_script10[collapsed=true]\r\e[0KDiagnostic ruby & gem information"
     # Diagnostic ruby & gem information
@@ -69,13 +69,11 @@ variables:
 
     # If RVM is available, make SURE it's using the right Ruby:
     #   * Source rvm (to run in non-login shells)
-    #   * If any $MATRIX_RUBY_VERSION rubies are available, use the latest
-    #   * Otherwise: install & use ${MATRIX_RUBY_VERSION}-head (e.g., latest)
-    #     * ^^ This could be wonky and introduce variations across runners
-    #     * ^^ maybe it should just fail if there is no $MATRIX_RUBY_VERSION installed?
+    #   * Use $MATRIX_RUBY_VERSION ruby, install if not present
     - echo -e "\e[0Ksection_start:`date +%s`:before_script20[collapsed=true]\r\e[0KEnsure RVM & ruby is installed"
-    - "command -v rvm && { if declare -p rvm_path &> /dev/null; then source \"${rvm_path}/scripts/rvm\"; else source \"$HOME/.rvm/scripts/rvm\" || source /etc/profile.d/rvm.sh; fi; }"
-    - "command -v rvm && { LATEST_RVM_RUBY_XY=\"$(rvm ls | grep \"$MATRIX_RUBY_VERSION\" | tail -1 | sed -e 's/^.*\\([0-9]\\+\\.[0-9]\\+\\.[0-9]\\+\\).*$/\\1/g')\"; if [ -z \"$LATEST_RVM_RUBY_XY\" ]; then LATEST_RVM_RUBY_XY=\"${MATRIX_RUBY_VERSION}-head\"; rvm install \"$LATEST_RVM_RUBY\" --no-docs; else echo \"Found RVM Ruby: '${LATEST_RVM_RUBY_XY}'\"; fi; rvm use \"$LATEST_RVM_RUBY_XY\" ;  }"
+    - "if command -v rvm; then if declare -p rvm_path &> /dev/null; then source \"${rvm_path}/scripts/rvm\"; else source \"$HOME/.rvm/scripts/rvm\" || source /etc/profile.d/rvm.sh; fi; fi"
+    - "if command -v rvm && ! grep rvm_install_on_use_flag=1 ~/.rvmrc; then echo rvm_install_on_use_flag=1 >> ~/.rvmrc || echo '== WARNING: ~/.rvmrc is missing rvm_install_on_use_flag=1 and I failed to add it'; fi"
+    - "if command -v rvm; then rvm use \"$MATRIX_RUBY_VERSION\"; else echo \"rvm not detected; skipping 'rvm use'\"; fi"
     - 'ruby --version || :'
     - 'gem list sync || :'
     - echo -e "\e[0Ksection_end:`date +%s`:before_script20\r\e[0K"


### PR DESCRIPTION
This patch fixes some problems with GitHub Actions release workflows:

* GLCI pipeline logic correctly handles when rvm is present but a desired
  ruby version is missing.  This used to fail silently during setup.
* GHA workflows no longer attempt to release when SemVer-compatible tags
  are pushed to a fork.

This patch also enforces the standardized asset baseline using
simp/puppetsync, and may apply other updates to ensure conformity.

CI: SKIP MATRIX
[SIMP-9473] #close
[SIMP-9408] #comment Fix silent RVM failures for pupmod-simp-pam
[SIMP-9399] #comment pupmod-simp-pam GHA won't try to release forks

[SIMP-9473]: https://simp-project.atlassian.net/browse/SIMP-9473
[SIMP-9408]: https://simp-project.atlassian.net/browse/SIMP-9408
[SIMP-9399]: https://simp-project.atlassian.net/browse/SIMP-9399