### PR TITLE
(SIMP-9627) Add quiet to pam_listfile

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@
   pam_tty_audit if the login did not have a tty.  This caused service logins to fail,
   specifically the gdm service.
 - Removed support for EL6.
+- Set the quiet parameter  when doing pam_listfile lookups in auth.pp  so that users
+  don't end up with warnings in the logs that look like authentication failures
 
 * Tue Aug 25 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.8.2-0
 - Use the fixed simplib__auditd fact for toggling pam_tty_audit

--- a/spec/expected/auth_spec/cracklib-system-auth_oath_enabled
+++ b/spec/expected/auth_spec/cracklib-system-auth_oath_enabled
@@ -4,8 +4,8 @@
 auth     optional      pam_faildelay.so
 auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 audit unlock_time=900 fail_interval=900 even_deny_root root_unlock_time=60
-auth     [success=3 default=ignore] pam_listfile.so item=group sense=allow file=/etc/liboath/exclude_groups.oath
-auth     [success=2 default=ignore] pam_listfile.so item=user sense=allow file=/etc/liboath/exclude_users.oath
+auth     [success=3 default=ignore] pam_listfile.so item=group sense=allow file=/etc/liboath/exclude_groups.oath quiet
+auth     [success=2 default=ignore] pam_listfile.so item=user sense=allow file=/etc/liboath/exclude_users.oath quiet
 auth     [success=1 default=bad]    pam_oath.so usersfile=/etc/liboath/users.oath window=1
 auth     requisite     pam_deny.so
 auth     [success=1 default=ignore] pam_unix.so try_first_pass

--- a/spec/expected/auth_spec/pwquality-system-auth_oath_enabled
+++ b/spec/expected/auth_spec/pwquality-system-auth_oath_enabled
@@ -4,8 +4,8 @@
 auth     optional      pam_faildelay.so
 auth     required      pam_env.so
 auth     required      pam_faillock.so preauth silent deny=5 audit unlock_time=900 fail_interval=900 even_deny_root root_unlock_time=60
-auth     [success=3 default=ignore] pam_listfile.so item=group sense=allow file=/etc/liboath/exclude_groups.oath
-auth     [success=2 default=ignore] pam_listfile.so item=user sense=allow file=/etc/liboath/exclude_users.oath
+auth     [success=3 default=ignore] pam_listfile.so item=group sense=allow file=/etc/liboath/exclude_groups.oath quiet
+auth     [success=2 default=ignore] pam_listfile.so item=user sense=allow file=/etc/liboath/exclude_users.oath quiet
 auth     [success=1 default=bad]    pam_oath.so usersfile=/etc/liboath/users.oath window=1
 auth     requisite     pam_deny.so
 auth     [success=1 default=ignore] pam_unix.so try_first_pass

--- a/templates/etc/pam.d/auth.epp
+++ b/templates/etc/pam.d/auth.epp
@@ -69,8 +69,8 @@ auth     sufficient    pam_fprintd.so
 auth     [success=done ignore=ignore default=die] pam_pkcs11.so wait_for_card card_only
 <% } -%>
 <% if $oath and ($name == 'system') { -%>
-auth     [success=3 default=ignore] pam_listfile.so item=group sense=allow file=/etc/liboath/exclude_groups.oath
-auth     [success=2 default=ignore] pam_listfile.so item=user sense=allow file=/etc/liboath/exclude_users.oath
+auth     [success=3 default=ignore] pam_listfile.so item=group sense=allow file=/etc/liboath/exclude_groups.oath quiet
+auth     [success=2 default=ignore] pam_listfile.so item=user sense=allow file=/etc/liboath/exclude_users.oath quiet
 auth     [success=1 default=bad]    pam_oath.so usersfile=/etc/liboath/users.oath window=<%= $oath_window %>
 auth     requisite     pam_deny.so
 <% } -%>


### PR DESCRIPTION
-  This adds the quiet parameter to pam_listfile entries in auth.pp so
   service refusals are not logged as errors.

SIMP-9627 #close