### PR TITLE
(#132) Added support for authselect

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue May 30 2023 Mike Riddle <mike@sicura.us> - 6.11.3
+- Added support for use of this module with authselect enabled
+
 * Thu Dec 15 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.11.2
 - Accomodate 'retry =' patch with EL versions earlier than 8.4
 

--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -109,7 +109,7 @@ define pam::auth (
     'smartcard',
     'fingerprint',
     'password',
-    'system'
+    'system',
   ]
 
   $_valid_targets_join = join($valid_targets,',')
@@ -117,7 +117,16 @@ define pam::auth (
     fail("\$name must be one of '${_valid_targets_join}'.")
   }
 
-  $basedir = '/etc/pam.d'
+  unless $pam::auth_basedir {
+    $basedir = $pam::use_authselect ? {
+      true => '/etc/pam.d/simp',
+      default => '/etc/pam.d',
+    }
+  }
+  else {
+    $basedir = $pam::auth_basedir
+  }
+
   $target = "${name}-auth"
 
   if $content {
@@ -130,47 +139,47 @@ define pam::auth (
     }
     else {
       $_content = epp("${module_name}/etc/pam.d/auth.epp", {
-        name                      => $name,
-        password_check_backend    => $password_check_backend,
-        locale_file               => $locale_file,
-        auth_content_pre          => $auth_content_pre,
-        cracklib_enforce_for_root => $cracklib_enforce_for_root,
-        cracklib_reject_username  => $cracklib_reject_username,
-        cracklib_difok            => $cracklib_difok,
-        cracklib_maxrepeat        => $cracklib_maxrepeat,
-        cracklib_maxsequence      => $cracklib_maxsequence,
-        cracklib_maxclassrepeat   => $cracklib_maxclassrepeat,
-        cracklib_gecoscheck       => $cracklib_gecoscheck,
-        cracklib_dcredit          => $cracklib_dcredit,
-        cracklib_ucredit          => $cracklib_ucredit,
-        cracklib_lcredit          => $cracklib_lcredit,
-        cracklib_ocredit          => $cracklib_ocredit,
-        cracklib_minclass         => $cracklib_minclass,
-        cracklib_minlen           => $cracklib_minlen,
-        cracklib_retry            => $cracklib_retry,
-        deny                      => $deny,
-        faillock                  => $faillock,
-        faillock_log_dir          => $faillock_log_dir,
-        display_account_lock      => $display_account_lock,
-        fail_interval             => $fail_interval,
-        remember                  => $remember,
-        remember_retry            => $remember_retry,
-        remember_for_root         => $remember_for_root,
-        even_deny_root            => $even_deny_root,
-        root_unlock_time          => $root_unlock_time,
-        hash_algorithm            => $hash_algorithm,
-        rounds                    => $rounds,
-        uid                       => $uid,
-        unlock_time               => $unlock_time,
-        preserve_ac               => $preserve_ac,
-        use_netgroups             => $use_netgroups,
-        use_openshift             => $use_openshift,
-        sssd                      => $sssd,
-        tty_audit_users           => $tty_audit_users,
-        separator                 => $separator,
-        enable_separator          => $enable_separator,
-        oath                      => $oath,
-        oath_window               => $oath_window
+          name                      => $name,
+          password_check_backend    => $password_check_backend,
+          locale_file               => $locale_file,
+          auth_content_pre          => $auth_content_pre,
+          cracklib_enforce_for_root => $cracklib_enforce_for_root,
+          cracklib_reject_username  => $cracklib_reject_username,
+          cracklib_difok            => $cracklib_difok,
+          cracklib_maxrepeat        => $cracklib_maxrepeat,
+          cracklib_maxsequence      => $cracklib_maxsequence,
+          cracklib_maxclassrepeat   => $cracklib_maxclassrepeat,
+          cracklib_gecoscheck       => $cracklib_gecoscheck,
+          cracklib_dcredit          => $cracklib_dcredit,
+          cracklib_ucredit          => $cracklib_ucredit,
+          cracklib_lcredit          => $cracklib_lcredit,
+          cracklib_ocredit          => $cracklib_ocredit,
+          cracklib_minclass         => $cracklib_minclass,
+          cracklib_minlen           => $cracklib_minlen,
+          cracklib_retry            => $cracklib_retry,
+          deny                      => $deny,
+          faillock                  => $faillock,
+          faillock_log_dir          => $faillock_log_dir,
+          display_account_lock      => $display_account_lock,
+          fail_interval             => $fail_interval,
+          remember                  => $remember,
+          remember_retry            => $remember_retry,
+          remember_for_root         => $remember_for_root,
+          even_deny_root            => $even_deny_root,
+          root_unlock_time          => $root_unlock_time,
+          hash_algorithm            => $hash_algorithm,
+          rounds                    => $rounds,
+          uid                       => $uid,
+          unlock_time               => $unlock_time,
+          preserve_ac               => $preserve_ac,
+          use_netgroups             => $use_netgroups,
+          use_openshift             => $use_openshift,
+          sssd                      => $sssd,
+          tty_audit_users           => $tty_audit_users,
+          separator                 => $separator,
+          enable_separator          => $enable_separator,
+          oath                      => $oath,
+          oath_window               => $oath_window
       })
     }
   }
@@ -180,12 +189,12 @@ define pam::auth (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    content => $_content
+    content => $_content,
   }
 
   if ! $preserve_ac {
     file { "${basedir}/${target}-ac":
-      ensure => absent
+      ensure => absent,
     }
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,7 +10,17 @@ class pam::config {
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    recurse => true
+    recurse => true,
+  }
+
+  if $pam::use_authselect {
+    file { '/etc/pam.d/simp':
+      ensure  => 'directory',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      recurse => true,
+    }
   }
 
   if ($pam::password_check_backend == 'pwquality') {
@@ -20,29 +30,29 @@ class pam::config {
       group   => 'root',
       mode    => '0644',
       content => epp("${module_name}/etc/security/pwquality.conf.epp", {
-        difok          => $pam::cracklib_difok,
-        maxrepeat      => $pam::cracklib_maxrepeat,
-        maxsequence    => $pam::cracklib_maxsequence,
-        maxclassrepeat => $pam::cracklib_maxclassrepeat,
-        gecoscheck     => $pam::cracklib_gecoscheck,
-        dcredit        => $pam::cracklib_dcredit,
-        ucredit        => $pam::cracklib_ucredit,
-        lcredit        => $pam::cracklib_lcredit,
-        ocredit        => $pam::cracklib_ocredit,
-        minclass       => $pam::cracklib_minclass,
-        minlen         => $pam::cracklib_minlen,
-        retry          => $pam::cracklib_retry,
-        badwords       => $pam::cracklib_badwords,
-        dictpath       => $pam::cracklib_dictpath,
-        dictcheck      => $pam::dictcheck
-      })
+          difok          => $pam::cracklib_difok,
+          maxrepeat      => $pam::cracklib_maxrepeat,
+          maxsequence    => $pam::cracklib_maxsequence,
+          maxclassrepeat => $pam::cracklib_maxclassrepeat,
+          gecoscheck     => $pam::cracklib_gecoscheck,
+          dcredit        => $pam::cracklib_dcredit,
+          ucredit        => $pam::cracklib_ucredit,
+          lcredit        => $pam::cracklib_lcredit,
+          ocredit        => $pam::cracklib_ocredit,
+          minclass       => $pam::cracklib_minclass,
+          minlen         => $pam::cracklib_minlen,
+          retry          => $pam::cracklib_retry,
+          badwords       => $pam::cracklib_badwords,
+          dictpath       => $pam::cracklib_dictpath,
+          dictcheck      => $pam::dictcheck
+      }),
     }
 
     if $pam::rm_pwquality_conf_d {
       # Ensure that we can't be overridden
       file { '/etc/security/pwquality.conf.d':
         ensure => 'absent',
-        force  => true
+        force  => true,
       }
     }
   }
@@ -52,8 +62,8 @@ class pam::config {
   }
   else {
     $_other_content = epp("${module_name}/etc/pam.d/other.epp", {
-      warn_if_unknown => $pam::warn_if_unknown,
-      deny_if_unknown => $pam::deny_if_unknown
+        warn_if_unknown => $pam::warn_if_unknown,
+        deny_if_unknown => $pam::deny_if_unknown
     })
   }
 
@@ -63,47 +73,47 @@ class pam::config {
       owner  => 'root',
       group  => 'root',
       mode   => '0644',
-    ;
-    [ '/etc/pam.d/atd', '/etc/pam.d/crond' ]:
-    ;
+      ;
+    ['/etc/pam.d/atd', '/etc/pam.d/crond']:
+      ;
     '/etc/pam.d/sudo':
-        content => epp('pam/etc/pam.d/sudo', {
+      content => epp('pam/etc/pam.d/sudo', {
           'pam_module_path' => 'system-auth',
           'force_revoke'    => false,
           'tty_audit_users' => $pam::tty_audit_users,
-        })
-    ;
+      })
+      ;
     '/etc/pam.d/sudo-i':
-        content => epp('pam/etc/pam.d/sudo', {
+      content => epp('pam/etc/pam.d/sudo', {
           'pam_module_path' => 'sudo',
           'force_revoke'    => true,
           'tty_audit_users' => $pam::tty_audit_users,
-        })
-    ;
+      })
+      ;
     '/etc/pam.d/other':
       content => $_other_content,
-    ;
+      ;
   }
 
   if ($facts['os']['release']['major'] <= '7') and ($pam::disable_authconfig == true) {
     # Replace authconfig and authconfig-tui with a no-op script
     # so that those tools can't be used to modify PAM.
-      file { '/usr/local/sbin/simp_authconfig.sh':
-        ensure  => 'file',
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0755',
-        content => file("${module_name}/simp_authconfig.sh")
-      }
+    file { '/usr/local/sbin/simp_authconfig.sh':
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      content => file("${module_name}/simp_authconfig.sh"),
+    }
 
-      file { [
+    file { [
         '/usr/sbin/authconfig',
-        '/usr/sbin/authconfig-tui'
-        ]:
+        '/usr/sbin/authconfig-tui',
+      ]:
         ensure  => 'link',
         target  => '/usr/local/sbin/simp_authconfig.sh',
-        require => File['/usr/local/sbin/simp_authconfig.sh']
-      }
+        require => File['/usr/local/sbin/simp_authconfig.sh'],
+    }
   }
 
   if ($pam::faillock_log_dir) {
@@ -115,9 +125,9 @@ class pam::config {
       seluser  => 'system_u',
       selrole  => 'object_r',
       seltype  => 'faillog_t',
-      selrange => 's0'
+      selrange => 's0',
     }
   }
 
-  if ! empty($pam::auth_sections) { ::pam::auth { $pam::auth_sections: }}
+  if ! empty($pam::auth_sections) { ::pam::auth { $pam::auth_sections: } }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -270,6 +270,15 @@
 #   Disable authconfig from being used, as it breaks this module's reconfiguration
 #   of PAM.
 #
+# @param use_authselect
+#   If true, the files created in this module will be created in a simp directory
+#   and authselect will simply include the files created under that new directory.
+#   In short, if this value is true, the files will be created the same way, they
+#   will just live under a different directory and be included by the original files
+#
+# @param auth_basedir
+#   The directory in which the auth files will be created
+#
 # @param package_ensure
 #   Ensure setting for all packages installed by this module
 #
@@ -319,11 +328,11 @@ class pam (
   Boolean                        $deny_if_unknown           = true,
   Boolean                        $use_netgroups             = false,
   Boolean                        $use_openshift             = false,
-  Boolean                        $sssd                      = simplib::lookup('simp_options::sssd', { 'default_value' => false}),
+  Boolean                        $sssd                      = simplib::lookup('simp_options::sssd', { 'default_value' => false }),
   Boolean                        $enable_separator          = true,
   String[0]                      $separator                 = ',',
-  Array[String[0]]               $tty_audit_users           = [ 'root' ],
-  Pam::AuthSections              $auth_sections             = [ 'fingerprint', 'system', 'password', 'smartcard' ],
+  Array[String[0]]               $tty_audit_users           = ['root'],
+  Pam::AuthSections              $auth_sections             = ['fingerprint', 'system', 'password', 'smartcard'],
   Optional[Array[String]]        $auth_content_pre          = undef,
   Optional[Array[String]]        $su_content_extra          = undef,
   Optional[String]               $su_content                = undef,
@@ -332,14 +341,14 @@ class pam (
   Optional[String]               $system_auth_content       = undef,
   Optional[String]               $password_auth_content     = undef,
   Optional[String]               $smartcard_auth_content    = undef,
+  Optional[StdLib::Absolutepath] $auth_basedir              = undef,
   Boolean                        $enable                    = true,
   Boolean                        $enable_warning            = true,
   Boolean                        $disable_authconfig        = true,
+  Boolean                        $use_authselect            = simplib::lookup('simp_options::authselect', { 'default_value' => false }),
   Simplib::PackageEnsure         $package_ensure            = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'present' })
 ) {
-
-
-  if simplib::lookup('simp_options::pam', { 'default_value' => true } ) {
+  if simplib::lookup('simp_options::pam', { 'default_value' => true }) {
     if $enable {
       simplib::assert_metadata( $module_name )
 
@@ -348,11 +357,10 @@ class pam (
 
       Class['pam::install']
       -> Class['pam::config']
-
     }
   }
   else {
-  # The global catalyst was set to false but the module was included
+    # The global catalyst was set to false but the module was included
     if $enable_warning {
       if simplib::lookup('simp_options::pam', { 'default_value' => true }) == false {
         warning('Module pupmod-simp-pam was included but global catalyst simp_options::pam is set to false. This could have unexpected effects.')

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pam",
-  "version": "6.11.2",
+  "version": "6.11.3",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing pam",
   "license": "Apache-2.0",


### PR DESCRIPTION
When using the pam module while authselect is enabled files will be created in a location that will be included by authselect rather than being overwritten.