### PR TITLE
[puppetsync] Update metadata upper bounds for puppet-nsswitch, puppet-gitlab, puppet-snmp, simp-pam, and simp-useradd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Feb 07 2024 Steven Pritchard <steve@sicura.us> - 7.1.0
+- [puppetsync] Add EL9 support
+
 
 * Wed Jan 31 2024 Mike Riddle <mike@sicura.us> - 7.0.0
 - Added functionality to control /etc/security/pwhistory.conf

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pam",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing pam",
   "license": "Apache-2.0",
@@ -30,7 +30,7 @@
     },
     {
       "name": "simp/useradd",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 0.2.2 < 2.0.0"
     }
   ],
   "simp": {


### PR DESCRIPTION
The patch enforces a standardized asset baseline using
simp/puppetsync, and may also apply other updates to
ensure conformity.