### PR TITLE
[puppetsync] Support simp-iptables 7.x

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Sep 13 2024 Steven Pritchard <steve@sicura.us> - 7.2.0
+- [puppetsync] Update module dependencies to support simp-iptables 7.x
+
 
 * Tue Apr 09 2024 Mike Riddle <mike@sicura.us> - 7.1.0
 - Added the cert_auth parameter

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pam",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing pam",
   "license": "Apache-2.0",
@@ -30,7 +30,7 @@
     },
     {
       "name": "simp/useradd",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 0.2.2 < 2.0.0"
     }
   ],
   "simp": {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,7 +100,6 @@ RSpec.configure do |c|
   c.mock_with :rspec
 
   c.module_path = File.join(fixture_path, 'modules')
-  c.manifest_dir = File.join(fixture_path, 'manifests') if c.respond_to?(:manifest_dir)
 
   c.hiera_config = File.join(fixture_path, 'hieradata', 'hiera.yaml')
 


### PR DESCRIPTION
Update module dependencies to support simp-iptables 7.x.