### PR TITLE
Remove references to archived SIMP modules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -20,7 +20,6 @@ fixtures:
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
     systemd: https://github.com/simp/puppet-systemd.git
     oath: https://github.com/simp/pupmod-simp-oath.git
-    tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers.git
     disa_stig-el7-baseline:
       repo: https://github.com/simp/inspec-profile-disa_stig-el7.git
       branch: master


### PR DESCRIPTION
Remove all references to the following archived modules: chkrootkit, hirs_provisioner, incron, network, rkhunter, simp_bolt, simp_ipa, simp_openldap, simp_pki_service, sudosh, tcpwrappers, tpm, xinetd

This includes removal from metadata.json dependencies, .fixtures.yml, Puppetfiles, manifests, spec tests, hiera data, and acceptance tests as applicable.