### PR TITLE
Fix pam_tty_audit idempotency; add tty_audit_enforcing parameter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+* Mon Jul 27 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 9.0.1
+- Fix a `pam_tty_audit` idempotency bug: the `sudo`, `sudo-i`, and `*-auth`
+  files keyed their `required`/`optional` decision on the live
+  `simplib__auditd` fact, which flips from `false` to `true` as the same
+  catalog enables auditd. This rewrote the PAM files on every other run and
+  broke idempotency (surfaced on EL8 in the SIMP acceptance suite).
+- Add the `pam::tty_audit_enforcing` parameter (default:
+  `simp_options::auditd`) to drive that decision from the intended auditd
+  state instead of the mutable runtime fact.
+
 * Thu May 21 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 9.0.0
 - Change smartcard-auth pam_sss.so control flag from
   `[success=done ignore=ignore default=die]` to `sufficient` to align with

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -90,6 +90,7 @@ The following parameters are available in the `pam` class:
 * [`use_openshift`](#-pam--use_openshift)
 * [`sssd`](#-pam--sssd)
 * [`tty_audit_users`](#-pam--tty_audit_users)
+* [`tty_audit_enforcing`](#-pam--tty_audit_enforcing)
 * [`enable_ssh_agent_auth`](#-pam--enable_ssh_agent_auth)
 * [`ssh_agent_auth_authorized_keys_command`](#-pam--ssh_agent_auth_authorized_keys_command)
 * [`su_content_extra`](#-pam--su_content_extra)
@@ -583,6 +584,23 @@ The users for which TTY auditing is enabled
 * Set to an empty Array to not audit TTY actions for any user
 
 Default value: `['root']`
+
+##### <a name="-pam--tty_audit_enforcing"></a>`tty_audit_enforcing`
+
+Data type: `Boolean`
+
+Whether `pam_tty_audit` should be `required` (as opposed to `optional`)
+in the generated PAM files
+
+* When `true`, TTY auditing is enforced; when `false`, it is optional so
+  that logins do not fail on systems where auditd is not active
+* Defaults to the `simp_options::auditd` catalyst so the value reflects
+  the *intended* auditd state. It intentionally does NOT read the live
+  `simplib__auditd` fact: that fact flips from `false` to `true` as the
+  same catalog enables auditd, which rewrote the PAM files on every run
+  and broke idempotency.
+
+Default value: `simplib::lookup('simp_options::auditd', { 'default_value' => false })`
 
 ##### <a name="-pam--enable_ssh_agent_auth"></a>`enable_ssh_agent_auth`
 
@@ -1269,6 +1287,7 @@ The following parameters are available in the `pam::auth` defined type:
 * [`use_openshift`](#-pam--auth--use_openshift)
 * [`sssd`](#-pam--auth--sssd)
 * [`tty_audit_users`](#-pam--auth--tty_audit_users)
+* [`tty_audit_enforcing`](#-pam--auth--tty_audit_enforcing)
 * [`separator`](#-pam--auth--separator)
 * [`enable_separator`](#-pam--auth--enable_separator)
 * [`inactive`](#-pam--auth--inactive)
@@ -1660,6 +1679,14 @@ Data type: `Array[String[0]]`
 
 
 Default value: `$pam::tty_audit_users`
+
+##### <a name="-pam--auth--tty_audit_enforcing"></a>`tty_audit_enforcing`
+
+Data type: `Boolean`
+
+
+
+Default value: `$pam::tty_audit_enforcing`
 
 ##### <a name="-pam--auth--separator"></a>`separator`
 

--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -54,6 +54,7 @@
 # @param use_openshift
 # @param sssd
 # @param tty_audit_users
+# @param tty_audit_enforcing
 # @param separator
 # @param enable_separator
 # @param inactive
@@ -111,6 +112,7 @@ define pam::auth (
   Boolean                         $use_openshift             = $pam::use_openshift,
   Boolean                         $sssd                      = $pam::sssd,
   Array[String[0]]                $tty_audit_users           = $pam::tty_audit_users,
+  Boolean                         $tty_audit_enforcing       = $pam::tty_audit_enforcing,
   String[0]                       $separator                 = $pam::separator,
   Boolean                         $enable_separator          = $pam::enable_separator,
   Boolean                         $oath                      = $pam::oath,
@@ -256,6 +258,7 @@ define pam::auth (
         use_openshift             => $use_openshift,
         sssd                      => $sssd,
         tty_audit_users           => $tty_audit_users,
+        tty_audit_enforcing       => $tty_audit_enforcing,
         separator                 => $separator,
         enable_separator          => $enable_separator,
         oath                      => $oath,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -108,6 +108,7 @@ class pam::config {
         'pam_module_path'                        => 'system-auth',
         'force_revoke'                           => false,
         'tty_audit_users'                        => $pam::tty_audit_users,
+        'tty_audit_enforcing'                    => $pam::tty_audit_enforcing,
         'enable_ssh_agent_auth'                  => $pam::enable_ssh_agent_auth,
         'ssh_agent_auth_authorized_keys_command' => $pam::ssh_agent_auth_authorized_keys_command,
       })
@@ -117,6 +118,7 @@ class pam::config {
         'pam_module_path'                        => 'sudo',
         'force_revoke'                           => true,
         'tty_audit_users'                        => $pam::tty_audit_users,
+        'tty_audit_enforcing'                    => $pam::tty_audit_enforcing,
         'enable_ssh_agent_auth'                  => $pam::enable_ssh_agent_auth,
         'ssh_agent_auth_authorized_keys_command' => $pam::ssh_agent_auth_authorized_keys_command,
       })

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -225,6 +225,18 @@
 #
 #   * Set to an empty Array to not audit TTY actions for any user
 #
+# @param tty_audit_enforcing
+#   Whether `pam_tty_audit` should be `required` (as opposed to `optional`)
+#   in the generated PAM files
+#
+#   * When `true`, TTY auditing is enforced; when `false`, it is optional so
+#     that logins do not fail on systems where auditd is not active
+#   * Defaults to the `simp_options::auditd` catalyst so the value reflects
+#     the *intended* auditd state. It intentionally does NOT read the live
+#     `simplib__auditd` fact: that fact flips from `false` to `true` as the
+#     same catalog enables auditd, which rewrote the PAM files on every run
+#     and broke idempotency.
+#
 # @param enable_ssh_agent_auth
 #   Install ``pam_ssh_agent_auth`` and enable it for ``sudo`` and ``sudo-i``
 #   so users may authenticate using an SSH agent identity whose public key
@@ -420,6 +432,7 @@ class pam (
   Boolean                         $enable_separator          = true,
   String[0]                       $separator                 = ',',
   Array[String[0]]                $tty_audit_users           = ['root'],
+  Boolean                         $tty_audit_enforcing       = simplib::lookup('simp_options::auditd', { 'default_value' => false }),
   Boolean                         $enable_ssh_agent_auth     = false,
   Stdlib::Absolutepath            $ssh_agent_auth_authorized_keys_command = '/usr/bin/sss_ssh_authorizedkeys',
   Pam::AuthSections               $auth_sections             = ['fingerprint', 'system', 'password', 'smartcard'],

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pam",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing pam",
   "license": "Apache-2.0",

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -261,16 +261,16 @@ describe 'pam' do
         it { is_expected.to contain_pam__auth('smartcard') }
       end
 
-      context 'when auditing is enabled' do
-        let(:facts) do
-          os_facts
-            .merge(
-              simplib__auditd: {
-                'enforcing' => true,
-              },
-            )
-        end
+      context 'when tty_audit_enforcing is true' do
+        # The default facts set simplib__auditd enforcing => false; the
+        # parameter (not the live fact) must drive the output so the files
+        # stay idempotent as auditd transitions to enforcing.
+        let(:params) { { tty_audit_enforcing: true } }
 
+        it {
+          is_expected.to contain_file('/etc/pam.d/sudo')
+            .with_content(%r{session\s+required\s+pam_tty_audit.so})
+        }
         it {
           is_expected.to contain_file('/etc/pam.d/sudo-i')
             .with_content(%r{session\s+required\s+pam_tty_audit.so})

--- a/spec/defines/auth_spec.rb
+++ b/spec/defines/auth_spec.rb
@@ -258,6 +258,24 @@ describe 'pam::auth' do
           end
         end
 
+        context 'with tty_audit_enforcing true' do
+          # The default facts set simplib__auditd enforcing => false; the
+          # parameter (not the live fact) must drive pam_tty_audit so the
+          # generated files stay idempotent as auditd transitions to enforcing.
+          ['fingerprint', 'password', 'system'].each do |auth_type|
+            context "auth type '#{auth_type}'" do
+              let(:title) { auth_type }
+              let(:params) { { tty_audit_enforcing: true } }
+              let(:filename) { "/etc/pam.d/#{auth_type}-auth" }
+
+              it {
+                is_expected.to contain_file(filename)
+                  .with_content(%r{session\s+required\s+pam_tty_audit.so})
+              }
+            end
+          end
+        end
+
         context 'Generate file using auth_content_pre params for Centrify' do
           let(:params) do
             {

--- a/templates/etc/pam.d/auth.epp
+++ b/templates/etc/pam.d/auth.epp
@@ -46,6 +46,7 @@
   Boolean                        $use_openshift,
   Boolean                        $sssd,
   Array[String[0]]               $tty_audit_users,
+  Boolean                        $tty_audit_enforcing,
   String[0]                      $separator,
   Boolean                        $enable_separator,
   Boolean                        $oath,
@@ -307,7 +308,7 @@ session      sufficient    pam_succeed_if.so service in crond quiet use_uid
 <% if ($name in ['system','password','fingerprint']) and !empty($tty_audit_users) { -%>
 # Check if session has a tty before running pam_tty_audit
 session      [default=ignore success=1] pam_succeed_if.so tty !~ ?* quiet
-<%-   if dig($facts, 'simplib__auditd', 'enforcing') { -%>
+<%-   if $tty_audit_enforcing { -%>
 session      required      pam_tty_audit.so disable=* enable=<%= $tty_audit_users.join(',') %>
 <%-   } else { -%>
 # auditd disabled: pam_tty_audit set to optional so that all logins do not fail

--- a/templates/etc/pam.d/sudo.epp
+++ b/templates/etc/pam.d/sudo.epp
@@ -4,6 +4,7 @@
       Array                      $tty_audit_users,
       Boolean                    $enable_ssh_agent_auth,
       Stdlib::Absolutepath       $ssh_agent_auth_authorized_keys_command,
+      Boolean                    $tty_audit_enforcing,
       Array[String]              $pam_types = ['auth','account','password']
 |
 -%>
@@ -20,7 +21,7 @@ auth sufficient pam_ssh_agent_auth.so authorized_keys_command=<%= $ssh_agent_aut
 session optional pam_keyinit.so <%= if $force_revoke { 'force ' } %>revoke
 session required pam_limits.so
 <%- unless empty($tty_audit_users) { -%>
-<%-   if dig($facts, 'simplib__auditd', 'enforcing') { -%>
+<%-   if $tty_audit_enforcing { -%>
 session required pam_tty_audit.so disable=* enable=<%= $tty_audit_users.join(',') %> open_only
 <%-   } else { -%>
 # auditd disabled: pam_tty_audit set to optional so that all logins do not fail


### PR DESCRIPTION
## Problem

The `sudo`, `sudo-i`, and `*-auth` PAM files choose `required` vs `optional` for `pam_tty_audit.so` based on the **live** `simplib__auditd.enforcing` fact:

```epp
<%- if dig($facts, 'simplib__auditd', 'enforcing') { -%>
session required pam_tty_audit.so ...
<%- } else { -%>
session optional pam_tty_audit.so ...
<%- } -%>
```

Because the same catalog transitions auditd into enforcing (`-e 2`) mode during convergence, that fact flips `false → true` between applies, so the PAM files are rewritten on the following run and **break idempotency**. This surfaced as the EL8 `simp class ... is idempotent` failure in the `pupmod-simp-simp` acceptance suite (`/etc/pam.d/{sudo,sudo-i,system-auth,password-auth,fingerprint-auth}` content changing on the second apply). It was hidden in pam's own suite, which never drives auditd to enforcing.

## Fix

Drive the decision from **intent**, not mutable runtime state:

- Add `pam::tty_audit_enforcing` (`Boolean`, default `simplib::lookup('simp_options::auditd', { 'default_value' => false })`) — the same catalyst pattern other modules use for auditd intent.
- Thread it through `pam::auth` and `pam::config` into `sudo.epp` / `auth.epp`, which now test `$tty_audit_enforcing` instead of the fact. Content is now deterministic across runs.
- Specs: the `required`-path tests drive off the parameter while the default facts keep `enforcing => false`, proving the parameter (not the fact) controls output.
- Regenerate `REFERENCE.md`; bump to `9.0.1`.

## Behavior

- **Steady state unchanged** on SIMP nodes: `simp_options::auditd` is `true` in a standard deploy, so PAM renders `required` consistently — the enforced end-state, without the flap.
- **Anti-lockout preserved**: with auditd not intended (`simp_options::auditd` false), it renders `optional`. Sites can override via `pam::tty_audit_enforcing`.
- One deliberate shift: a standalone box with auditd enforcing but `simp_options::auditd` unset now renders `optional` (still idempotent and safe) rather than reading the live fact.

## Verification

- `puppet parser validate` + `puppet-lint` clean.
- Unit suite green (`auth_spec` + `config_spec` 3669/0; remaining 3907/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)