### PR TITLE
Add opt-in pam::cracklib_retry_in_auth_file parameter (OEL 9 STIG V-271612)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,12 @@
-* Tue Jul 28 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 9.1.0
-- Emit the `pam_pwquality` `retry` option in the `system-auth` and
-  `password-auth` files on Oracle Linux 9, whose DISA STIG (V-271612) checks
-  the PAM files rather than `pwquality.conf`. `retry` is still written to
-  `pwquality.conf` as well.
-- Add the `pam::cracklib_retry_in_auth_file` parameter (default `false`,
-  set `true` for OEL 9 via `data/os/OracleLinux-9.yaml`) to drive this. Other
-  EL8+ platforms (RHEL/AlmaLinux/Rocky/CentOS 9 and EL10) are unchanged and
-  continue to enforce `retry` via `pwquality.conf`.
+* Wed Jul 29 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 9.1.0
+- Add the `pam::cracklib_retry_in_auth_file` parameter (default `false`). When
+  set, the `pam_pwquality` `retry` option is also emitted on the password line
+  of the `system-auth` and `password-auth` files. This is additive: `retry`
+  continues to be written to `pwquality.conf`.
+- Provided for platforms whose STIG checks the PAM files rather than
+  `pwquality.conf` for `retry` (e.g. Oracle Linux 9, V-271612). It is opt-in
+  and not enabled by default on any platform; enable it via the compliance /
+  site data layer where required.
 
 * Thu May 21 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 9.0.0
 - Change smartcard-auth pam_sss.so control flag from

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+* Tue Jul 28 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 9.1.0
+- Emit the `pam_pwquality` `retry` option in the `system-auth` and
+  `password-auth` files on Oracle Linux 9, whose DISA STIG (V-271612) checks
+  the PAM files rather than `pwquality.conf`. `retry` is still written to
+  `pwquality.conf` as well.
+- Add the `pam::cracklib_retry_in_auth_file` parameter (default `false`,
+  set `true` for OEL 9 via `data/os/OracleLinux-9.yaml`) to drive this. Other
+  EL8+ platforms (RHEL/AlmaLinux/Rocky/CentOS 9 and EL10) are unchanged and
+  continue to enforce `retry` via `pwquality.conf`.
+
 * Thu May 21 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 9.0.0
 - Change smartcard-auth pam_sss.so control flag from
   `[success=done ignore=ignore default=die]` to `sufficient` to align with

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -59,6 +59,7 @@ The following parameters are available in the `pam` class:
 * [`cracklib_minlen`](#-pam--cracklib_minlen)
 * [`cracklib_reject_username`](#-pam--cracklib_reject_username)
 * [`cracklib_retry`](#-pam--cracklib_retry)
+* [`cracklib_retry_in_auth_file`](#-pam--cracklib_retry_in_auth_file)
 * [`cracklib_badwords`](#-pam--cracklib_badwords)
 * [`cracklib_dictpath`](#-pam--cracklib_dictpath)
 * [`dictcheck`](#-pam--dictcheck)
@@ -309,6 +310,20 @@ Data type: `Integer[0]`
 Prompt user at most N times before returning with error
 
 Default value: `3`
+
+##### <a name="-pam--cracklib_retry_in_auth_file"></a>`cracklib_retry_in_auth_file`
+
+Data type: `Boolean`
+
+Also emit the ``pam_pwquality``/``pam_cracklib`` ``retry`` option on the
+``password`` line of the ``system-auth`` and ``password-auth`` files, even
+on platforms that otherwise enforce it via ``pwquality.conf``.
+
+* Defaults to ``false``. Set ``true`` only where a platform's STIG requires
+  ``retry`` in the auth files (e.g. Oracle Linux 9, STIG V-271612). This is
+  additive: ``retry`` is still written to ``pwquality.conf`` as well.
+
+Default value: `false`
 
 ##### <a name="-pam--cracklib_badwords"></a>`cracklib_badwords`
 
@@ -1273,6 +1288,7 @@ The following parameters are available in the `pam::auth` defined type:
 * [`enable_separator`](#-pam--auth--enable_separator)
 * [`inactive`](#-pam--auth--inactive)
 * [`cert_auth`](#-pam--auth--cert_auth)
+* [`cracklib_retry_in_auth_file`](#-pam--auth--cracklib_retry_in_auth_file)
 * [`faillock_conf_supported`](#-pam--auth--faillock_conf_supported)
 * [`pwhistory_conf_supported`](#-pam--auth--pwhistory_conf_supported)
 * [`content`](#-pam--auth--content)
@@ -1692,6 +1708,14 @@ Data type: `Optional[Enum['try','require']]`
 
 
 Default value: `$pam::cert_auth`
+
+##### <a name="-pam--auth--cracklib_retry_in_auth_file"></a>`cracklib_retry_in_auth_file`
+
+Data type: `Boolean`
+
+
+
+Default value: `$pam::cracklib_retry_in_auth_file`
 
 ##### <a name="-pam--auth--faillock_conf_supported"></a>`faillock_conf_supported`
 

--- a/data/os/OracleLinux-9.yaml
+++ b/data/os/OracleLinux-9.yaml
@@ -1,0 +1,9 @@
+---
+# Oracle Linux 9-specific settings
+#
+# OEL 9's DISA STIG (V-271612) checks /etc/pam.d/system-auth for the
+# pam_pwquality "retry" option and requires it there, unlike RHEL 9 and its
+# derivatives (RHEL-09/V-258091), which check /etc/security/pwquality.conf.
+# Emit retry on the PAM password line as well; it is still written to
+# pwquality.conf.
+pam::cracklib_retry_in_auth_file: true

--- a/data/os/OracleLinux-9.yaml
+++ b/data/os/OracleLinux-9.yaml
@@ -1,9 +1,0 @@
----
-# Oracle Linux 9-specific settings
-#
-# OEL 9's DISA STIG (V-271612) checks /etc/pam.d/system-auth for the
-# pam_pwquality "retry" option and requires it there, unlike RHEL 9 and its
-# derivatives (RHEL-09/V-258091), which check /etc/security/pwquality.conf.
-# Emit retry on the PAM password line as well; it is still written to
-# pwquality.conf.
-pam::cracklib_retry_in_auth_file: true

--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -58,6 +58,7 @@
 # @param enable_separator
 # @param inactive
 # @param cert_auth
+# @param cracklib_retry_in_auth_file
 # @param faillock_conf_supported
 # @param pwhistory_conf_supported
 # @param content
@@ -119,6 +120,7 @@ define pam::auth (
   Optional[Enum['try','require']] $cert_auth                 = $pam::cert_auth,
   Boolean                         $faillock_conf_supported   = $pam::faillock_conf_supported,
   Boolean                         $pwhistory_conf_supported  = $pam::pwhistory_conf_supported,
+  Boolean                         $cracklib_retry_in_auth_file = $pam::cracklib_retry_in_auth_file,
   Optional[String]                $content                   = undef
 ) {
   include 'oddjob::mkhomedir'
@@ -191,11 +193,17 @@ define pam::auth (
         default => false
       }
 
-      # retry, enforce_for_root, and reject_username will be enforced via
-      # pwquality.conf in EL8+ and Amazon Linux 2022+
-      $_cracklib_retry = $faillock_conf_supported ? {
-        true    => false,
-        default => $cracklib_retry
+      # retry, enforce_for_root, and reject_username are normally enforced via
+      # pwquality.conf in EL8+ and Amazon Linux 2022+. Oracle Linux 9's STIG
+      # (V-271612) additionally requires the pam_pwquality retry option on the
+      # password line of the auth files, so $cracklib_retry_in_auth_file is set
+      # true there via OS data. retry remains in pwquality.conf as well; this
+      # only also emits it on the PAM line.
+      if $faillock_conf_supported and !$cracklib_retry_in_auth_file {
+        $_cracklib_retry = false
+      }
+      else {
+        $_cracklib_retry = $cracklib_retry
       }
 
       $_cracklib_enforce_for_root = $faillock_conf_supported ? {

--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -194,11 +194,12 @@ define pam::auth (
       }
 
       # retry, enforce_for_root, and reject_username are normally enforced via
-      # pwquality.conf in EL8+ and Amazon Linux 2022+. Oracle Linux 9's STIG
-      # (V-271612) additionally requires the pam_pwquality retry option on the
-      # password line of the auth files, so $cracklib_retry_in_auth_file is set
-      # true there via OS data. retry remains in pwquality.conf as well; this
-      # only also emits it on the PAM line.
+      # pwquality.conf in EL8+ and Amazon Linux 2022+. Some platforms' STIGs
+      # instead check the auth files for the pam_pwquality retry option (e.g.
+      # Oracle Linux 9, V-271612). Enabling the opt-in $cracklib_retry_in_auth_file
+      # parameter -- expected to be set via compliance or site data, not by
+      # default -- also emits retry on the PAM password line; retry remains in
+      # pwquality.conf as well.
       if $faillock_conf_supported and !$cracklib_retry_in_auth_file {
         $_cracklib_retry = false
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -108,6 +108,15 @@
 # @param cracklib_retry
 #   Prompt user at most N times before returning with error
 #
+# @param cracklib_retry_in_auth_file
+#   Also emit the ``pam_pwquality``/``pam_cracklib`` ``retry`` option on the
+#   ``password`` line of the ``system-auth`` and ``password-auth`` files, even
+#   on platforms that otherwise enforce it via ``pwquality.conf``.
+#
+#   * Defaults to ``false``. Set ``true`` only where a platform's STIG requires
+#     ``retry`` in the auth files (e.g. Oracle Linux 9, STIG V-271612). This is
+#     additive: ``retry`` is still written to ``pwquality.conf`` as well.
+#
 # @param cracklib_badwords
 #   Array of words that must not be contained in the password.
 #   These are additional words to the cracklib dictionary check.
@@ -394,6 +403,7 @@ class pam (
   Integer[0]                      $cracklib_minclass         = 3,
   Integer[0]                      $cracklib_minlen           = 15,
   Integer[0]                      $cracklib_retry            = 3,
+  Boolean                         $cracklib_retry_in_auth_file = false,
   Optional[Array[String[1],1]]    $cracklib_badwords         = undef,
   Optional[StdLib::Absolutepath]  $cracklib_dictpath         = undef,
   Integer[0]                      $dictcheck                 = 1,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-pam",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing pam",
   "license": "Apache-2.0",

--- a/spec/defines/auth_spec.rb
+++ b/spec/defines/auth_spec.rb
@@ -9,6 +9,23 @@ def get_expected(filename)
   IO.read(path)
 end
 
+# Oracle Linux 9's STIG (V-271612) requires the pam_pwquality "retry" option on
+# the password line of system-auth/password-auth, unlike other EL8+ platforms
+# which enforce it via pwquality.conf. The generated content is otherwise
+# identical to the shared el8 expectation, so derive the OEL 9 expectation by
+# inserting retry on the pwquality password line (a no-op for other OSes and
+# for auth types that do not emit that line).
+def get_expected_os(filename, os_facts, cracklib_retry: 3)
+  content = get_expected(filename)
+  if os_facts.dig(:os, :name) == 'OracleLinux' && os_facts.dig(:os, :release, :major).to_i == 9
+    content = content.sub(
+      'requisite     pam_pwquality.so',
+      "requisite     pam_pwquality.so retry=#{cracklib_retry}",
+    )
+  end
+  content
+end
+
 shared_examples_for 'a pam.d config file generator' do
   it { is_expected.to compile.with_all_deps }
   it { is_expected.to create_class('oddjob::mkhomedir') }
@@ -53,10 +70,28 @@ describe 'pam::auth' do
                 end
               end
               let(:filename) { "/etc/pam.d/#{auth_type}-auth" }
-              let(:file_content) { get_expected("#{pw_backend}-#{auth_type}-#{el_version}-auth_default_params") }
+              let(:file_content) { get_expected_os("#{pw_backend}-#{auth_type}-#{el_version}-auth_default_params", os_facts) }
 
               it_behaves_like 'a pam.d config file generator'
               it { is_expected.to contain_file(filename).with_content(file_content) }
+            end
+          end
+        end
+
+        # OEL 9's STIG (V-271612) requires the pam_pwquality retry option in the
+        # system-auth/password-auth files; other EL8+ platforms enforce it via
+        # pwquality.conf only. See data/os/OracleLinux-9.yaml.
+        context 'pam_pwquality retry in the auth files (STIG V-271612)' do
+          ['system', 'password'].each do |auth_type|
+            context "auth type '#{auth_type}'" do
+              let(:title) { auth_type }
+              let(:filename) { "/etc/pam.d/#{auth_type}-auth" }
+
+              if (os_facts[:os][:name] == 'OracleLinux') && (os_facts[:os][:release][:major].to_i == 9)
+                it { is_expected.to contain_file(filename).with_content(%r{^password\s+requisite\s+pam_pwquality\.so retry=3$}) }
+              else
+                it { is_expected.not_to contain_file(filename).with_content(%r{pam_pwquality\.so.*retry=}) }
+              end
             end
           end
         end
@@ -117,7 +152,7 @@ describe 'pam::auth' do
                 end
               end
               let(:filename) { "/etc/pam.d/#{auth_type}-auth" }
-              let(:file_content) { get_expected("#{pw_backend}-#{auth_type}-#{el_version}-auth_unlock_time_never") }
+              let(:file_content) { get_expected_os("#{pw_backend}-#{auth_type}-#{el_version}-auth_unlock_time_never", os_facts) }
 
               it_behaves_like 'a pam.d config file generator'
               it { is_expected.to contain_file(filename).with_content(file_content) }
@@ -221,7 +256,7 @@ describe 'pam::auth' do
                 end
               end
               let(:filename) { "/etc/pam.d/#{auth_type}-auth" }
-              let(:file_content) { get_expected("#{pw_backend}-#{auth_type}-#{el_version}-auth_sssd_no_tty_audit") }
+              let(:file_content) { get_expected_os("#{pw_backend}-#{auth_type}-#{el_version}-auth_sssd_no_tty_audit", os_facts, cracklib_retry: 10) }
 
               it_behaves_like 'a pam.d config file generator'
               it { is_expected.to contain_file(filename).with_content(file_content) }
@@ -250,7 +285,7 @@ describe 'pam::auth' do
                 end
               end
               let(:filename) { "/etc/pam.d/#{auth_type}-auth" }
-              let(:file_content) { get_expected("#{pw_backend}-#{auth_type}-#{el_version}-auth_sssd_openshift_multi_tty_audit") }
+              let(:file_content) { get_expected_os("#{pw_backend}-#{auth_type}-#{el_version}-auth_sssd_openshift_multi_tty_audit", os_facts) }
 
               it_behaves_like 'a pam.d config file generator'
               it { is_expected.to contain_file(filename).with_content(file_content) }
@@ -286,7 +321,7 @@ describe 'pam::auth' do
                 end
               end
               let(:filename) { "/etc/pam.d/#{auth_type}-auth" }
-              let(:file_content) { get_expected("#{pw_backend}-#{auth_type}-#{el_version}-auth_sssd_user_specified_centrify") }
+              let(:file_content) { get_expected_os("#{pw_backend}-#{auth_type}-#{el_version}-auth_sssd_user_specified_centrify", os_facts) }
 
               it_behaves_like 'a pam.d config file generator'
               it { is_expected.to contain_file(filename).with_content(file_content) }
@@ -315,7 +350,7 @@ describe 'pam::auth' do
                   'el8'
                 end
               end
-              let(:file_content) { get_expected("#{pw_backend}-#{el_version}-password-separator-#{index}") }
+              let(:file_content) { get_expected_os("#{pw_backend}-#{el_version}-password-separator-#{index}", os_facts) }
 
               it_behaves_like 'a pam.d config file generator'
               it { is_expected.to contain_file(filename).with_content(file_content) }
@@ -339,7 +374,7 @@ describe 'pam::auth' do
               'el8'
             end
           end
-          let(:file_content) { get_expected("#{pw_backend}-#{el_version}-password-separator-false") }
+          let(:file_content) { get_expected_os("#{pw_backend}-#{el_version}-password-separator-false", os_facts) }
 
           it_behaves_like 'a pam.d config file generator'
           it { is_expected.to contain_file(filename).with_content(file_content) }
@@ -361,7 +396,7 @@ describe 'pam::auth' do
               'el8'
             end
           end
-          let(:file_content) { get_expected("#{pw_backend}-system-#{el_version}-auth_oath_enabled") }
+          let(:file_content) { get_expected_os("#{pw_backend}-system-#{el_version}-auth_oath_enabled", os_facts) }
 
           it_behaves_like 'a pam.d config file generator'
           it { is_expected.to contain_file(filename).with_content(file_content) }
@@ -383,7 +418,7 @@ describe 'pam::auth' do
               'el8'
             end
           end
-          let(:file_content) { get_expected("#{pw_backend}-system-#{el_version}-auth_nullok") }
+          let(:file_content) { get_expected_os("#{pw_backend}-system-#{el_version}-auth_nullok", os_facts) }
 
           it_behaves_like 'a pam.d config file generator'
           it { is_expected.to contain_file(filename).with_content(file_content) }

--- a/spec/defines/auth_spec.rb
+++ b/spec/defines/auth_spec.rb
@@ -9,23 +9,6 @@ def get_expected(filename)
   IO.read(path)
 end
 
-# Oracle Linux 9's STIG (V-271612) requires the pam_pwquality "retry" option on
-# the password line of system-auth/password-auth, unlike other EL8+ platforms
-# which enforce it via pwquality.conf. The generated content is otherwise
-# identical to the shared el8 expectation, so derive the OEL 9 expectation by
-# inserting retry on the pwquality password line (a no-op for other OSes and
-# for auth types that do not emit that line).
-def get_expected_os(filename, os_facts, cracklib_retry: 3)
-  content = get_expected(filename)
-  if os_facts.dig(:os, :name) == 'OracleLinux' && os_facts.dig(:os, :release, :major).to_i == 9
-    content = content.sub(
-      'requisite     pam_pwquality.so',
-      "requisite     pam_pwquality.so retry=#{cracklib_retry}",
-    )
-  end
-  content
-end
-
 shared_examples_for 'a pam.d config file generator' do
   it { is_expected.to compile.with_all_deps }
   it { is_expected.to create_class('oddjob::mkhomedir') }
@@ -70,7 +53,7 @@ describe 'pam::auth' do
                 end
               end
               let(:filename) { "/etc/pam.d/#{auth_type}-auth" }
-              let(:file_content) { get_expected_os("#{pw_backend}-#{auth_type}-#{el_version}-auth_default_params", os_facts) }
+              let(:file_content) { get_expected("#{pw_backend}-#{auth_type}-#{el_version}-auth_default_params") }
 
               it_behaves_like 'a pam.d config file generator'
               it { is_expected.to contain_file(filename).with_content(file_content) }
@@ -78,20 +61,19 @@ describe 'pam::auth' do
           end
         end
 
-        # OEL 9's STIG (V-271612) requires the pam_pwquality retry option in the
-        # system-auth/password-auth files; other EL8+ platforms enforce it via
-        # pwquality.conf only. See data/os/OracleLinux-9.yaml.
-        context 'pam_pwquality retry in the auth files (STIG V-271612)' do
+        # cracklib_retry_in_auth_file lets a site emit the pam_pwquality retry
+        # option on the password line of system-auth/password-auth (opt-in;
+        # e.g. required by the Oracle Linux 9 STIG, V-271612). It is off by
+        # default -- EL8+ otherwise enforces retry via pwquality.conf (verified
+        # by the default-params content above).
+        context 'with cracklib_retry_in_auth_file => true' do
           ['system', 'password'].each do |auth_type|
             context "auth type '#{auth_type}'" do
               let(:title) { auth_type }
+              let(:params) { { cracklib_retry_in_auth_file: true } }
               let(:filename) { "/etc/pam.d/#{auth_type}-auth" }
 
-              if (os_facts[:os][:name] == 'OracleLinux') && (os_facts[:os][:release][:major].to_i == 9)
-                it { is_expected.to contain_file(filename).with_content(%r{^password\s+requisite\s+pam_pwquality\.so retry=3$}) }
-              else
-                it { is_expected.not_to contain_file(filename).with_content(%r{pam_pwquality\.so.*retry=}) }
-              end
+              it { is_expected.to contain_file(filename).with_content(%r{^password\s+requisite\s+pam_pwquality\.so retry=3$}) }
             end
           end
         end
@@ -152,7 +134,7 @@ describe 'pam::auth' do
                 end
               end
               let(:filename) { "/etc/pam.d/#{auth_type}-auth" }
-              let(:file_content) { get_expected_os("#{pw_backend}-#{auth_type}-#{el_version}-auth_unlock_time_never", os_facts) }
+              let(:file_content) { get_expected("#{pw_backend}-#{auth_type}-#{el_version}-auth_unlock_time_never") }
 
               it_behaves_like 'a pam.d config file generator'
               it { is_expected.to contain_file(filename).with_content(file_content) }
@@ -256,7 +238,7 @@ describe 'pam::auth' do
                 end
               end
               let(:filename) { "/etc/pam.d/#{auth_type}-auth" }
-              let(:file_content) { get_expected_os("#{pw_backend}-#{auth_type}-#{el_version}-auth_sssd_no_tty_audit", os_facts, cracklib_retry: 10) }
+              let(:file_content) { get_expected("#{pw_backend}-#{auth_type}-#{el_version}-auth_sssd_no_tty_audit") }
 
               it_behaves_like 'a pam.d config file generator'
               it { is_expected.to contain_file(filename).with_content(file_content) }
@@ -285,7 +267,7 @@ describe 'pam::auth' do
                 end
               end
               let(:filename) { "/etc/pam.d/#{auth_type}-auth" }
-              let(:file_content) { get_expected_os("#{pw_backend}-#{auth_type}-#{el_version}-auth_sssd_openshift_multi_tty_audit", os_facts) }
+              let(:file_content) { get_expected("#{pw_backend}-#{auth_type}-#{el_version}-auth_sssd_openshift_multi_tty_audit") }
 
               it_behaves_like 'a pam.d config file generator'
               it { is_expected.to contain_file(filename).with_content(file_content) }
@@ -321,7 +303,7 @@ describe 'pam::auth' do
                 end
               end
               let(:filename) { "/etc/pam.d/#{auth_type}-auth" }
-              let(:file_content) { get_expected_os("#{pw_backend}-#{auth_type}-#{el_version}-auth_sssd_user_specified_centrify", os_facts) }
+              let(:file_content) { get_expected("#{pw_backend}-#{auth_type}-#{el_version}-auth_sssd_user_specified_centrify") }
 
               it_behaves_like 'a pam.d config file generator'
               it { is_expected.to contain_file(filename).with_content(file_content) }
@@ -350,7 +332,7 @@ describe 'pam::auth' do
                   'el8'
                 end
               end
-              let(:file_content) { get_expected_os("#{pw_backend}-#{el_version}-password-separator-#{index}", os_facts) }
+              let(:file_content) { get_expected("#{pw_backend}-#{el_version}-password-separator-#{index}") }
 
               it_behaves_like 'a pam.d config file generator'
               it { is_expected.to contain_file(filename).with_content(file_content) }
@@ -374,7 +356,7 @@ describe 'pam::auth' do
               'el8'
             end
           end
-          let(:file_content) { get_expected_os("#{pw_backend}-#{el_version}-password-separator-false", os_facts) }
+          let(:file_content) { get_expected("#{pw_backend}-#{el_version}-password-separator-false") }
 
           it_behaves_like 'a pam.d config file generator'
           it { is_expected.to contain_file(filename).with_content(file_content) }
@@ -396,7 +378,7 @@ describe 'pam::auth' do
               'el8'
             end
           end
-          let(:file_content) { get_expected_os("#{pw_backend}-system-#{el_version}-auth_oath_enabled", os_facts) }
+          let(:file_content) { get_expected("#{pw_backend}-system-#{el_version}-auth_oath_enabled") }
 
           it_behaves_like 'a pam.d config file generator'
           it { is_expected.to contain_file(filename).with_content(file_content) }
@@ -418,7 +400,7 @@ describe 'pam::auth' do
               'el8'
             end
           end
-          let(:file_content) { get_expected_os("#{pw_backend}-system-#{el_version}-auth_nullok", os_facts) }
+          let(:file_content) { get_expected("#{pw_backend}-system-#{el_version}-auth_nullok") }
 
           it_behaves_like 'a pam.d config file generator'
           it { is_expected.to contain_file(filename).with_content(file_content) }


### PR DESCRIPTION
Fixes #206

## What this does

Adds an opt-in `pam::cracklib_retry_in_auth_file` parameter (`Boolean`, default `false`). When set, the `pam_pwquality` `retry` option is also emitted on the `password requisite pam_pwquality.so` line of `system-auth`/`password-auth`. This is **additive** — `retry` continues to be written to `pwquality.conf` as it is today.

It is **off by default on every platform**; there is no per-OS default. Sites whose STIG requires `retry` in the PAM files enable it via their compliance / site data layer.

## Why

I verified the actual DISA STIG **check content** (the titles are misleading — RHEL 9/10's `retry` findings are titled "...system-auth file" but their checks grep `pwquality.conf`). See the [matrix on #206](https://github.com/simp/pupmod-simp-pam/issues/206#issuecomment-5108839269):

| Platform | Finding | `retry` checked in | Auth file? |
|---|---|---|---|
| **OEL 9** | V-271612 | `/etc/pam.d/system-auth` | **Required** |
| RHEL 9 | V-258091 | `pwquality.conf` | No |
| RHEL 10 | V-281204 | `pwquality.conf` | No |
| OEL 8 (8.4+) | V-252660 | `pwquality.conf` — **finding if present in the pam files** | Forbidden |

So this must never be a broad default: enabling it where it isn't wanted (e.g. RHEL/Alma/Rocky/CentOS) adds an unnecessary line, and on OEL 8 it would be an actual finding. `enforce_for_root` (checked in `pwquality.conf` on OEL 9 too, V-271621) and `reject_username` (no distinct STIG control) are intentionally left untouched — this is scoped to `retry` only.

The module provides the *capability*; the *policy* (which platforms/profiles enable it) belongs in the compliance data layer, consistent with how other STIG values are applied.

## Tests

- A `with cracklib_retry_in_auth_file => true` context asserts `retry=3` is emitted on the `pam_pwquality.so` line of `system-auth`/`password-auth`.
- "Off by default" is covered by the existing default-params content (no `retry` in the auth files).
- `auth_spec` 2913 examples, 0 failures; puppet-lint + rubocop clean. Bumped 9.0.0 -> 9.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)